### PR TITLE
Use 'coordinates' instead of individual arrays

### DIFF
--- a/doc/api/_generate_api.rst
+++ b/doc/api/_generate_api.rst
@@ -12,4 +12,3 @@ To include a new package/module, list it below and include it in api.index.rst
 
    verde
    verde.datasets
-   verde.base

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -5,4 +5,3 @@ API Reference
 
 .. include:: verde.rst
 .. include:: verde.datasets.rst
-.. include:: verde.base.rst

--- a/examples/data/synthetic_checkerboard.py
+++ b/examples/data/synthetic_checkerboard.py
@@ -17,8 +17,8 @@ print("region:", synth.region_)
 print("wavelengths (east, north):", synth.w_east, synth.w_north)
 
 # The CheckerBoard class behaves like any gridder class
-print("Checkerboard value at (2000, -2500):",
-      synth.predict(easting=2000, northing=-2500))
+print("Checkerboard value at (easting=2000, northing=-2500):",
+      synth.predict((2000, -2500)))
 
 # Generating a grid results in a xarray.Dataset
 grid = synth.grid()

--- a/examples/scipygridder.py
+++ b/examples/scipygridder.py
@@ -38,10 +38,10 @@ lon, lat, bathymetry = vd.block_reduce(data.longitude, data.latitude,
 # Project the data using pyproj so that we can use it as input for the gridder.
 # We'll set the latitude of true scale to the mean latitude of the data.
 projection = pyproj.Proj(proj='merc', lat_ts=data.latitude.mean())
-easting, northing = projection(lon, lat)
+coordinates = projection(lon, lat)
 
 # Now we can set up a gridder for the decimated data
-grd = vd.ScipyGridder(method='cubic').fit(easting, northing, bathymetry)
+grd = vd.ScipyGridder(method='cubic').fit(coordinates, bathymetry)
 print("Gridder used:", grd)
 
 # Get the grid region in geographic coordinates

--- a/examples/trend.py
+++ b/examples/trend.py
@@ -22,12 +22,12 @@ print("Original data:")
 print(data.head())
 
 # Fit a 2nd degree 2D polynomial to the anomaly data
-trend = vd.Trend(degree=2).fit(data.longitude, data.latitude,
-                               data.total_field_anomaly_nt)
+coordinates = (data.longitude, data.latitude)
+trend = vd.Trend(degree=2).fit(coordinates, data.total_field_anomaly_nt)
 print("\nTrend estimator:", trend)
 
 # Add the estimated trend and the residual data to the DataFrame
-data['trend'] = trend.predict(data.longitude, data.latitude)
+data['trend'] = trend.predict(coordinates)
 data['residual'] = trend.residual_
 print("\nUpdated DataFrame:")
 print(data.head())

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -5,6 +5,7 @@ from ._version import get_versions as _get_versions
 
 # Import functions/classes to make the API
 from . import datasets
+from .base import BaseGridder
 from .coordinates import scatter_points, grid_coordinates, inside, \
     profile_coordinates, block_region, get_region
 from .grid_math import block_reduce

--- a/verde/base.py
+++ b/verde/base.py
@@ -5,7 +5,300 @@ import xarray as xr
 import pandas as pd
 from sklearn.base import BaseEstimator
 
-from ..coordinates import grid_coordinates, profile_coordinates, scatter_points
+from .coordinates import grid_coordinates, profile_coordinates, scatter_points
+
+
+class BaseGridder(BaseEstimator):
+    """
+    Base class for gridders.
+
+    Requires the implementation of the ``predict(coordiantes)`` method. The
+    data returned by it should be a 1d or 2d numpy array for scalar data or a
+    tuple with 1d or 2d numpy arrays for each component of vector data.
+
+    Doesn't define any new attributes.
+
+    This is a subclass of :class:`sklearn.base.BaseEstimator` and must abide by
+    the same rules of the scikit-learn classes. Mainly:
+
+    * ``__init__`` must **only** assign values to attributes based on the
+      parameters it receives. All parameters must have default values.
+      Parameter checking should be done in ``fit``.
+    * Estimated parameters should be stored as attributes with names ending in
+      ``_``.
+
+    The child class can define the following attributes to control the names of
+    coordinates and data values in the output ``xarray.Dataset`` and
+    ``pandas.DataFrame`` and how distances are calculated:
+
+    * ``coordinate_system``: either ``'cartesian'`` or ``'geographic'``. Will
+      influence dimension names and distance calculations. Defaults to
+      ``'cartesian'``.
+    * ``data_type``: one of ``'scalar'``, ``'vector2d'``, or ``'vector3d'``.
+      Defaults to ``'scalar'``.
+
+    Examples
+    --------
+
+    Let's create a class that interpolates by attributing the mean value of the
+    data to every single point (it's not a very good interpolator).
+
+    >>> import verde as vd
+    >>> import numpy as np
+    >>> from sklearn.utils.validation import check_is_fitted
+    >>> class MeanGridder(vd.base.BaseGridder):
+    ...     "Gridder that always produces the mean of all data values"
+    ...     def __init__(self, multiplier=1):
+    ...         # Init should only assign the parameters to attributes
+    ...         self.multiplier = multiplier
+    ...     def fit(self, coordiantes, data):
+    ...         # Argument checking should be done in fit
+    ...         if self.multiplier <= 0:
+    ...             raise ValueError('Invalid multiplier {}'
+    ...                              .format(self.multiplier))
+    ...         self.mean_ = data.mean()*self.multiplier
+    ...         # fit should return self so that we can chain operations
+    ...         return self
+    ...     def predict(self, coordinates):
+    ...         # We know the gridder has been fitted if it has the mean
+    ...         check_is_fitted(self, ['mean_'])
+    ...         return np.ones_like(coordinates[0])*self.mean_
+    >>> # Try it on some synthetic data
+    >>> synthetic = vd.datasets.CheckerBoard().fit(region=(0, 5, -10, 8))
+    >>> data = synthetic.scatter()
+    >>> print('{:.4f}'.format(data.scalars.mean()))
+    -32.2182
+    >>> # Fit the gridder to our synthetic data
+    >>> grd = MeanGridder().fit((data.easting, data.northing), data.scalars)
+    >>> grd
+    MeanGridder(multiplier=1)
+    >>> # Interpolate on a regular grid
+    >>> grid = grd.grid(region=(0, 5, -10, -8), shape=(30, 20))
+    >>> type(grid)
+    <class 'xarray.core.dataset.Dataset'>
+    >>> np.allclose(grid.scalars, -32.2182)
+    True
+    >>> # Interpolate along a profile
+    >>> profile = grd.profile(point1=(0, -10), point2=(5, -8), size=10)
+    >>> type(profile)
+    <class 'pandas.core.frame.DataFrame'>
+    >>> print(', '.join(['{:.2f}'.format(i) for i in profile.distance]))
+    0.00, 0.60, 1.20, 1.80, 2.39, 2.99, 3.59, 4.19, 4.79, 5.39
+    >>> print(', '.join(['{:.1f}'.format(i) for i in profile.scalars]))
+    -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2
+
+    """
+
+    def predict(self, coordinates):
+        """
+        Interpolate data on the given set of points.
+
+        This method is required for all other methods related to interpolation.
+
+        Parameters
+        ----------
+        coordinates : tuple of arrays
+            Arrays with the coordinates of each computation point. Should be in
+            the following order: (easting, northing, vertical, ...)
+
+        Returns
+        -------
+        data : array or tuple of arrays
+            The data values interpolated on the given points. If the data are
+            scalars, then it should be a single array. If data are vectors,
+            then should be a tuple with a separate array for each vector
+            component. The order of components should be: east, north,
+            vertical.
+
+        """
+        raise NotImplementedError()
+
+    def grid(self, region=None, shape=None, spacing=None, adjust='spacing',
+             dims=None, data_names=None, projection=None):
+        """
+        Interpolate the data onto a regular grid.
+
+        The grid can be specified by either the number of points in each
+        dimension (the *shape*) or by the grid node spacing.
+
+        If the given region is not divisible by the desired spacing, either the
+        region or the spacing will have to be adjusted. By default, the spacing
+        will be rounded to the nearest multiple. Optionally, the East and North
+        boundaries of the region can be adjusted to fit the exact spacing
+        given. See :func:`verde.grid_coordinates` for more details.
+
+        If the interpolator collected the input data region, then it will be
+        used if ``region=None``. Otherwise, you must specify the grid region.
+
+        Use the *dims* and *data_names* arguments to set custom names for the
+        dimensions and the data field(s) in the output :class:`xarray.Dataset`.
+        Default names are provided.
+
+        Parameters
+        ----------
+        region : list = [W, E, S, N]
+            The boundaries of a given region in Cartesian or geographic
+            coordinates.
+        shape : tuple = (n_north, n_east) or None
+            The number of points in the South-North and West-East directions,
+            respectively. If *None* and *spacing* is not given, defaults to
+            ``(101, 101)``.
+        spacing : tuple = (s_north, s_east) or None
+            The grid spacing in the South-North and West-East directions,
+            respectively.
+        adjust : {'spacing', 'region'}
+            Whether to adjust the spacing or the region if required. Ignored if
+            *shape* is given instead of *spacing*. Defaults to adjusting the
+            spacing.
+        dims : list or None
+            The names of the northing and easting data dimensions,
+            respectively, in the output grid. Defaults to
+            ``['northing', 'easting']`` for Cartesian grids and
+            ``['latitude', 'longitude']`` for geographic grids.
+        data_names : list of None
+            The name(s) of the data variables in the output grid. Defaults to
+            ``['scalars']`` for scalar data,
+            ``['east_component', 'north_component']`` for 2D vector data, and
+            ``['east_component', 'north_component', 'vertical_component']`` for
+            3D vector data.
+
+        Returns
+        -------
+        grid : xarray.Dataset
+            The interpolated grid. Metadata about the interpolator is written
+            to the ``attrs`` attribute.
+
+        See also
+        --------
+        verde.grid_coordinates : Generate the coordinate values for the grid.
+
+        """
+        if shape is None and spacing is None:
+            shape = (101, 101)
+        dims = get_dims(self, dims)
+        data_names = get_data_names(self, data_names)
+        region = get_region(self, region)
+        coordinates = grid_coordinates(region, shape=shape, spacing=spacing,
+                                       adjust=adjust)
+        if projection is None:
+            data = check_data(self.predict(coordinates))
+        else:
+            data = check_data(self.predict(projection(*coordinates)))
+        coords = {dims[1]: coordinates[0][0, :], dims[0]: coordinates[1][:, 0]}
+        attrs = {'metadata': 'Generated by {}'.format(repr(self))}
+        data_vars = {name: (dims, value, attrs)
+                     for name, value in zip(data_names, data)}
+        return xr.Dataset(data_vars, coords=coords, attrs=attrs)
+
+    def scatter(self, region=None, size=300, random_state=0, dims=None,
+                data_names=None, projection=None):
+        """
+        Interpolate values onto a random scatter of points.
+
+        If the interpolator collected the input data region, then it will be
+        used if ``region=None``. Otherwise, you must specify the grid region.
+
+        Use the *dims* and *data_names* arguments to set custom names for the
+        dimensions and the data field(s) in the output
+        :class:`pandas.DataFrame`. Default names are provided.
+
+        Parameters
+        ----------
+        region : list = [W, E, S, N]
+            The boundaries of a given region in Cartesian or geographic
+            coordinates.
+        size : int
+            The number of points to generate.
+        random_state : numpy.random.RandomState or an int seed
+            A random number generator used to define the state of the random
+            permutations. Use a fixed seed to make sure computations are
+            reproducible. Use ``None`` to choose a seed automatically
+            (resulting in different numbers with each run).
+        dims : list or None
+            The names of the northing and easting data dimensions,
+            respectively, in the output dataframe. Defaults to
+            ``['northing', 'easting']`` for Cartesian grids and
+            ``['latitude', 'longitude']`` for geographic grids.
+        data_names : list of None
+            The name(s) of the data variables in the output dataframe. Defaults
+            to ``['scalars']`` for scalar data,
+            ``['east_component', 'north_component']`` for 2D vector data, and
+            ``['east_component', 'north_component', 'vertical_component']`` for
+            3D vector data.
+
+        Returns
+        -------
+        table : pandas.DataFrame
+            The interpolated values on a random set of points.
+
+        """
+        dims = get_dims(self, dims)
+        data_names = get_data_names(self, data_names)
+        region = get_region(self, region)
+        coordinates = scatter_points(region, size, random_state)
+        if projection is None:
+            data = check_data(self.predict(coordinates))
+        else:
+            data = check_data(self.predict(projection(*coordinates)))
+        columns = [(dims[0], coordinates[1]), (dims[1], coordinates[0])]
+        columns.extend(zip(data_names, data))
+        return pd.DataFrame(dict(columns), columns=[c[0] for c in columns])
+
+    def profile(self, point1, point2, size, dims=None, data_names=None,
+                projection=None):
+        """
+        Interpolate data along a profile between two points.
+
+        Generates the profile using a straight line if the interpolator assumes
+        Cartesian data or a great circle if geographic data.
+
+        Use the *dims* and *data_names* arguments to set custom names for the
+        dimensions and the data field(s) in the output
+        :class:`pandas.DataFrame`. Default names are provided.
+
+        Includes the calculated distance to *point1* for each data point in the
+        profile.
+
+        Parameters
+        ----------
+        point1 : tuple
+            The easting and northing coordinates, respectively, of the first
+            point.
+        point2 : tuple
+            The easting and northing coordinates, respectively, of the second
+            point.
+        size : int
+            The number of points to generate.
+        dims : list or None
+            The names of the northing and easting data dimensions,
+            respectively, in the output dataframe. Defaults to
+            ``['northing', 'easting']`` for Cartesian grids and
+            ``['latitude', 'longitude']`` for geographic grids.
+        data_names : list of None
+            The name(s) of the data variables in the output dataframe. Defaults
+            to ``['scalars']`` for scalar data,
+            ``['east_component', 'north_component']`` for 2D vector data, and
+            ``['east_component', 'north_component', 'vertical_component']`` for
+            3D vector data.
+
+        Returns
+        -------
+        table : pandas.DataFrame
+            The interpolated values along the profile.
+
+        """
+        coordsys = getattr(self, 'coordinate_system', 'cartesian')
+        dims = get_dims(self, dims)
+        data_names = get_data_names(self, data_names)
+        east, north, distances = profile_coordinates(
+            point1, point2, size, coordinate_system=coordsys)
+        if projection is None:
+            data = check_data(self.predict((east, north)))
+        else:
+            data = check_data(self.predict(projection(east, north)))
+        columns = [(dims[0], north), (dims[1], east), ('distance', distances)]
+        columns.extend(zip(data_names, data))
+        return pd.DataFrame(dict(columns), columns=[c[0] for c in columns])
 
 
 def get_dims(instance, dims):
@@ -102,298 +395,3 @@ def check_data(data):
     if not isinstance(data, tuple):
         data = (data,)
     return data
-
-
-class BaseGridder(BaseEstimator):
-    """
-    Base class for gridders.
-
-    Requires the implementation of the ``predict(easting, northing)`` method.
-    The data returned by it should be a 1d or 2d numpy array for scalar data or
-    a tuple with 1d or 2d numpy arrays for each component of vector data.
-
-    Doesn't define any new attributes.
-
-    This is a subclass of :class:`sklearn.base.BaseEstimator` and must abide by
-    the same rules of the scikit-learn classes. Mainly:
-
-    * ``__init__`` must **only** assign values to attributes based on the
-      parameters it receives. All parameters must have default values.
-      Parameter checking should be done in ``fit``.
-    * Estimated parameters should be stored as attributes with names ending in
-      ``_``.
-
-    The child class can define the following attributes to control the names of
-    coordinates and data values in the output ``xarray.Dataset`` and
-    ``pandas.DataFrame`` and how distances are calculated:
-
-    * ``coordinate_system``: either ``'cartesian'`` or ``'geographic'``. Will
-      influence dimension names and distance calculations. Defaults to
-      ``'cartesian'``.
-    * ``data_type``: one of ``'scalar'``, ``'vector2d'``, or ``'vector3d'``.
-      Defaults to ``'scalar'``.
-
-    Examples
-    --------
-
-    Let's create a class that interpolates by attributing the mean value of the
-    data to every single point (it's not a very good interpolator).
-
-    >>> import verde as vd
-    >>> import numpy as np
-    >>> from sklearn.utils.validation import check_is_fitted
-    >>> class MeanGridder(vd.base.BaseGridder):
-    ...     "Gridder that always produces the mean of all data values"
-    ...     def __init__(self, multiplier=1):
-    ...         # Init should only assign the parameters to attributes
-    ...         self.multiplier = multiplier
-    ...     def fit(self, easting, northing, data):
-    ...         # Argument checking should be done in fit
-    ...         if self.multiplier <= 0:
-    ...             raise ValueError('Invalid multiplier {}'
-    ...                              .format(self.multiplier))
-    ...         self.mean_ = data.mean()*self.multiplier
-    ...         # fit should return self so that we can chain operations
-    ...         return self
-    ...     def predict(self, easting, northing):
-    ...         # We know the gridder has been fitted if it has the mean
-    ...         check_is_fitted(self, ['mean_'])
-    ...         return np.ones_like(easting)*self.mean_
-    >>> # Try it on some synthetic data
-    >>> synthetic = vd.datasets.CheckerBoard().fit(region=(0, 5, -10, 8))
-    >>> data = synthetic.scatter()
-    >>> print('{:.4f}'.format(data.scalars.mean()))
-    -32.2182
-    >>> # Fit the gridder to our synthetic data
-    >>> grd = MeanGridder().fit(data.easting, data.northing, data.scalars)
-    >>> grd
-    MeanGridder(multiplier=1)
-    >>> # Interpolate on a regular grid
-    >>> grid = grd.grid(region=(0, 5, -10, -8), shape=(30, 20))
-    >>> type(grid)
-    <class 'xarray.core.dataset.Dataset'>
-    >>> np.allclose(grid.scalars, -32.2182)
-    True
-    >>> # Interpolate along a profile
-    >>> profile = grd.profile(point1=(0, -10), point2=(5, -8), size=10)
-    >>> type(profile)
-    <class 'pandas.core.frame.DataFrame'>
-    >>> print(', '.join(['{:.2f}'.format(i) for i in profile.distance]))
-    0.00, 0.60, 1.20, 1.80, 2.39, 2.99, 3.59, 4.19, 4.79, 5.39
-    >>> print(', '.join(['{:.1f}'.format(i) for i in profile.scalars]))
-    -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2
-
-
-    """
-
-    def predict(self, easting, northing):
-        """
-        Interpolate data on the given set of points.
-
-        This method is required for all other methods related to interpolation.
-
-        Parameters
-        ----------
-        easting : array
-            The values of the West-East coordinates of each data point.
-        northing : array
-            The values of the South-North coordinates of each data point.
-
-        Returns
-        -------
-        data : array or tuple of arrays
-            The data values interpolated on the given points. If the data are
-            scalars, then it should be a single array. If data are vectors,
-            then should be a tuple with a separate array for each vector
-            component. The order of components should be: east, north,
-            vertical.
-
-        """
-        raise NotImplementedError()
-
-    def grid(self, region=None, shape=None, spacing=None, adjust='spacing',
-             dims=None, data_names=None, projection=None):
-        """
-        Interpolate the data onto a regular grid.
-
-        The grid can be specified by either the number of points in each
-        dimension (the *shape*) or by the grid node spacing.
-
-        If the given region is not divisible by the desired spacing, either the
-        region or the spacing will have to be adjusted. By default, the spacing
-        will be rounded to the nearest multiple. Optionally, the East and North
-        boundaries of the region can be adjusted to fit the exact spacing
-        given. See :func:`verde.grid_coordinates` for more details.
-
-        If the interpolator collected the input data region, then it will be
-        used if ``region=None``. Otherwise, you must specify the grid region.
-
-        Use the *dims* and *data_names* arguments to set custom names for the
-        dimensions and the data field(s) in the output :class:`xarray.Dataset`.
-        Default names are provided.
-
-        Parameters
-        ----------
-        region : list = [W, E, S, N]
-            The boundaries of a given region in Cartesian or geographic
-            coordinates.
-        shape : tuple = (n_north, n_east) or None
-            The number of points in the South-North and West-East directions,
-            respectively. If *None* and *spacing* is not given, defaults to
-            ``(101, 101)``.
-        spacing : tuple = (s_north, s_east) or None
-            The grid spacing in the South-North and West-East directions,
-            respectively.
-        adjust : {'spacing', 'region'}
-            Whether to adjust the spacing or the region if required. Ignored if
-            *shape* is given instead of *spacing*. Defaults to adjusting the
-            spacing.
-        dims : list or None
-            The names of the northing and easting data dimensions,
-            respectively, in the output grid. Defaults to
-            ``['northing', 'easting']`` for Cartesian grids and
-            ``['latitude', 'longitude']`` for geographic grids.
-        data_names : list of None
-            The name(s) of the data variables in the output grid. Defaults to
-            ``['scalars']`` for scalar data,
-            ``['east_component', 'north_component']`` for 2D vector data, and
-            ``['east_component', 'north_component', 'vertical_component']`` for
-            3D vector data.
-
-        Returns
-        -------
-        grid : xarray.Dataset
-            The interpolated grid. Metadata about the interpolator is written
-            to the ``attrs`` attribute.
-
-        See also
-        --------
-        verde.grid_coordinates : Generate the coordinate values for the grid.
-
-        """
-        if shape is None and spacing is None:
-            shape = (101, 101)
-        dims = get_dims(self, dims)
-        data_names = get_data_names(self, data_names)
-        region = get_region(self, region)
-        easting, northing = grid_coordinates(region, shape=shape,
-                                             spacing=spacing, adjust=adjust)
-        if projection is None:
-            data = check_data(self.predict(easting, northing))
-        else:
-            data = check_data(self.predict(*projection(easting, northing)))
-        coords = {dims[1]: easting[0, :], dims[0]: northing[:, 0]}
-        attrs = {'metadata': 'Generated by {}'.format(repr(self))}
-        data_vars = {name: (dims, value, attrs)
-                     for name, value in zip(data_names, data)}
-        return xr.Dataset(data_vars, coords=coords, attrs=attrs)
-
-    def scatter(self, region=None, size=300, random_state=0, dims=None,
-                data_names=None, projection=None):
-        """
-        Interpolate values onto a random scatter of points.
-
-        If the interpolator collected the input data region, then it will be
-        used if ``region=None``. Otherwise, you must specify the grid region.
-
-        Use the *dims* and *data_names* arguments to set custom names for the
-        dimensions and the data field(s) in the output
-        :class:`pandas.DataFrame`. Default names are provided.
-
-        Parameters
-        ----------
-        region : list = [W, E, S, N]
-            The boundaries of a given region in Cartesian or geographic
-            coordinates.
-        size : int
-            The number of points to generate.
-        random_state : numpy.random.RandomState or an int seed
-            A random number generator used to define the state of the random
-            permutations. Use a fixed seed to make sure computations are
-            reproducible. Use ``None`` to choose a seed automatically
-            (resulting in different numbers with each run).
-        dims : list or None
-            The names of the northing and easting data dimensions,
-            respectively, in the output dataframe. Defaults to
-            ``['northing', 'easting']`` for Cartesian grids and
-            ``['latitude', 'longitude']`` for geographic grids.
-        data_names : list of None
-            The name(s) of the data variables in the output dataframe. Defaults
-            to ``['scalars']`` for scalar data,
-            ``['east_component', 'north_component']`` for 2D vector data, and
-            ``['east_component', 'north_component', 'vertical_component']`` for
-            3D vector data.
-
-        Returns
-        -------
-        table : pandas.DataFrame
-            The interpolated values on a random set of points.
-
-        """
-        dims = get_dims(self, dims)
-        data_names = get_data_names(self, data_names)
-        region = get_region(self, region)
-        east, north = scatter_points(region, size, random_state)
-        if projection is None:
-            data = check_data(self.predict(east, north))
-        else:
-            data = check_data(self.predict(*projection(east, north)))
-        columns = [(dims[0], north), (dims[1], east)]
-        columns.extend(zip(data_names, data))
-        return pd.DataFrame(dict(columns), columns=[c[0] for c in columns])
-
-    def profile(self, point1, point2, size, dims=None, data_names=None,
-                projection=None):
-        """
-        Interpolate data along a profile between two points.
-
-        Generates the profile using a straight line if the interpolator assumes
-        Cartesian data or a great circle if geographic data.
-
-        Use the *dims* and *data_names* arguments to set custom names for the
-        dimensions and the data field(s) in the output
-        :class:`pandas.DataFrame`. Default names are provided.
-
-        Includes the calculated distance to *point1* for each data point in the
-        profile.
-
-        Parameters
-        ----------
-        point1 : tuple
-            The easting and northing coordinates, respectively, of the first
-            point.
-        point2 : tuple
-            The easting and northing coordinates, respectively, of the second
-            point.
-        size : int
-            The number of points to generate.
-        dims : list or None
-            The names of the northing and easting data dimensions,
-            respectively, in the output dataframe. Defaults to
-            ``['northing', 'easting']`` for Cartesian grids and
-            ``['latitude', 'longitude']`` for geographic grids.
-        data_names : list of None
-            The name(s) of the data variables in the output dataframe. Defaults
-            to ``['scalars']`` for scalar data,
-            ``['east_component', 'north_component']`` for 2D vector data, and
-            ``['east_component', 'north_component', 'vertical_component']`` for
-            3D vector data.
-
-        Returns
-        -------
-        table : pandas.DataFrame
-            The interpolated values along the profile.
-
-        """
-        coordsys = getattr(self, 'coordinate_system', 'cartesian')
-        dims = get_dims(self, dims)
-        data_names = get_data_names(self, data_names)
-        east, north, distances = profile_coordinates(
-            point1, point2, size, coordinate_system=coordsys)
-        if projection is None:
-            data = check_data(self.predict(east, north))
-        else:
-            data = check_data(self.predict(*projection(east, north)))
-        columns = [(dims[0], north), (dims[1], east), ('distance', distances)]
-        columns.extend(zip(data_names, data))
-        return pd.DataFrame(dict(columns), columns=[c[0] for c in columns])

--- a/verde/base/__init__.py
+++ b/verde/base/__init__.py
@@ -1,4 +1,0 @@
-"""
-Base classes for all gridders.
-"""
-from .gridder import BaseGridder

--- a/verde/datasets/synthetic.py
+++ b/verde/datasets/synthetic.py
@@ -4,7 +4,7 @@ Generators of synthetic datasets.
 import numpy as np
 from sklearn.utils.validation import check_is_fitted
 
-from ..base.gridder import BaseGridder
+from ..base import BaseGridder
 from ..coordinates import check_region
 
 
@@ -143,16 +143,17 @@ class CheckerBoard(BaseGridder):
         self.region_ = region
         return self
 
-    def predict(self, easting, northing):
+    def predict(self, coordinates):
         """
         Evaluate the checkerboard function on a given set of points.
 
         Parameters
         ----------
-        easting : array
-            The values of the West-East coordinates of each data point.
-        northing : array
-            The values of the South-North coordinates of each data point.
+        coordinates : tuple of arrays
+            Arrays with the coordinates of each data point. Should be in the
+            following order: (easting, northing, vertical, ...). Only easting
+            and northing will be used, all subsequent coordinates will be
+            ignored.
 
         Returns
         -------
@@ -161,6 +162,7 @@ class CheckerBoard(BaseGridder):
 
         """
         check_is_fitted(self, ['region_'])
+        easting, northing = coordinates[:2]
         data = (self.amplitude *
                 np.sin((2*np.pi/self.w_east)*easting) *
                 np.cos((2*np.pi/self.w_north)*northing))

--- a/verde/scipy_bridge.py
+++ b/verde/scipy_bridge.py
@@ -45,7 +45,7 @@ class ScipyGridder(BaseGridder):
         self.method = method
         self.extra_args = extra_args
 
-    def fit(self, easting, northing, data):
+    def fit(self, coordinates, data):
         """
         Fit the interpolator to the given data.
 
@@ -58,10 +58,11 @@ class ScipyGridder(BaseGridder):
 
         Parameters
         ----------
-        easting : array
-            The values of the West-East coordinates of each data point.
-        northing : array
-            The values of the South-North coordinates of each data point.
+        coordinates : tuple of arrays
+            Arrays with the coordinates of each data point. Should be in the
+            following order: (easting, northing, vertical, ...). Only easting
+            and northing will be used, all subsequent coordinates will be
+            ignored.
         data : array
             The data values that will be interpolated.
 
@@ -82,13 +83,14 @@ class ScipyGridder(BaseGridder):
             kwargs = {}
         else:
             kwargs = self.extra_args
+        easting, northing = coordinates[:2]
         self.region_ = get_region(easting, northing)
         points = np.column_stack((np.ravel(easting), np.ravel(northing)))
         self.interpolator_ = classes[self.method](points, np.ravel(data),
                                                   **kwargs)
         return self
 
-    def predict(self, easting, northing):
+    def predict(self, coordinates):
         """
         Interpolate data on the given set of points.
 
@@ -96,10 +98,11 @@ class ScipyGridder(BaseGridder):
 
         Parameters
         ----------
-        easting : array
-            The values of the West-East coordinates of each data point.
-        northing : array
-            The values of the South-North coordinates of each data point.
+        coordinates : tuple of arrays
+            Arrays with the coordinates of each data point. Should be in the
+            following order: (easting, northing, vertical, ...). Only easting
+            and northing will be used, all subsequent coordinates will be
+            ignored.
 
         Returns
         -------
@@ -108,4 +111,4 @@ class ScipyGridder(BaseGridder):
 
         """
         check_is_fitted(self, ['interpolator_'])
-        return self.interpolator_((easting, northing))
+        return self.interpolator_(coordinates[:2])


### PR DESCRIPTION
All fit and predict methods have been changed to use a `coordinates`
tuple instead of `easting, northing`. This will allow the classes to be
used in more generic methods that take in more than 2 coordinates, like
equivalent layers.

Move the `base` subpackage back to a module and import `BaseGridder` in
the main API.

Needed for #42
