### PR TITLE
Make sure ScipyGridder.predict uses tuples

### DIFF
--- a/verde/scipy_bridge.py
+++ b/verde/scipy_bridge.py
@@ -126,4 +126,5 @@ class ScipyGridder(BaseGridder):
 
         """
         check_is_fitted(self, ['interpolator_'])
-        return self.interpolator_(coordinates[:2])
+        easting, northing = coordinates[:2]
+        return self.interpolator_((easting, northing))


### PR DESCRIPTION
If coordinates are in a list, passing that along to the interpolator
causes a failure. Unpack the coordinates and pass them along in a tuple
to make sure it works.
