### PR TITLE
Standardize functions to use coordinates tuples

### DIFF
--- a/examples/block_reduce.py
+++ b/examples/block_reduce.py
@@ -19,9 +19,10 @@ import verde as vd
 data = vd.datasets.fetch_baja_bathymetry()
 
 # Decimate the data using a blocked median with 10 arc-minute blocks
-lon, lat, bathymetry = vd.block_reduce(
-    data.longitude, data.latitude, data.bathymetry_m,
+coordinates, bathymetry = vd.block_reduce(
+    coordinates=(data.longitude, data.latitude), data=data.bathymetry_m,
     reduction=np.median, spacing=10/60)
+lon, lat = coordinates
 
 print("Original data size:", data.bathymetry_m.size)
 print("Decimated data size:", bathymetry.size)

--- a/examples/data/sample_california_gps.py
+++ b/examples/data/sample_california_gps.py
@@ -28,7 +28,7 @@ def setup_map(ax):
     ax.set_yticks(np.arange(33, 42, 2), crs=crs)
     ax.xaxis.set_major_formatter(LongitudeFormatter())
     ax.yaxis.set_major_formatter(LatitudeFormatter())
-    ax.set_extent(vd.get_region(data.longitude, data.latitude), crs=crs)
+    ax.set_extent(vd.get_region((data.longitude, data.latitude)), crs=crs)
     # Plot the land and ocean as a solid color
     ax.add_feature(cfeature.LAND)
     ax.add_feature(cfeature.OCEAN)

--- a/examples/data/sample_rio_magnetic_anomaly.py
+++ b/examples/data/sample_rio_magnetic_anomaly.py
@@ -41,6 +41,6 @@ ax.set_yticks(np.arange(-22.4, -22, 0.1), crs=crs)
 ax.xaxis.set_major_formatter(LongitudeFormatter())
 ax.yaxis.set_major_formatter(LatitudeFormatter())
 # Set the extent of the plot to the limits of the data
-ax.set_extent(vd.get_region(data.longitude, data.latitude), crs=crs)
+ax.set_extent(vd.get_region((data.longitude, data.latitude)), crs=crs)
 plt.tight_layout()
 plt.show()

--- a/examples/distance_mask.py
+++ b/examples/distance_mask.py
@@ -15,17 +15,17 @@ import verde as vd
 # The Baja California bathymetry dataset has big gaps on land. We want to mask
 # these gaps on a grid that we'll generate over the region
 data = vd.datasets.fetch_baja_bathymetry()
-region = vd.get_region(data.longitude, data.latitude)
+region = vd.get_region((data.longitude, data.latitude))
 
 # Generate the coordinates and a dummy grid with only ones that we'll want to
 # mask
 spacing = 10/60
-lons, lats = vd.grid_coordinates(region, spacing=spacing)
-dummy_data = np.ones_like(lons)
+coordinates = vd.grid_coordinates(region, spacing=spacing)
+dummy_data = np.ones_like(coordinates[0])
 
 # Generate a mask for points that are more than 2 grid spacings away from any
 # data point. The mask is True for points that are too far.
-mask = vd.distance_mask(lons, lats, data.longitude, data.latitude,
+mask = vd.distance_mask(coordinates, (data.longitude, data.latitude),
                         maxdist=spacing*2)
 print(mask)
 
@@ -38,7 +38,7 @@ plt.figure(figsize=(7, 6))
 ax = plt.axes(projection=ccrs.Mercator())
 ax.set_title('Only grid points that are close to data', pad=25)
 ax.plot(data.longitude, data.latitude, '.y', markersize=0.5, transform=crs)
-ax.pcolormesh(lons, lats, dummy_data, transform=crs)
+ax.pcolormesh(*coordinates, dummy_data, transform=crs)
 ax.gridlines(draw_labels=True)
 ax.set_extent(region, crs=crs)
 plt.tight_layout()

--- a/examples/trend.py
+++ b/examples/trend.py
@@ -51,7 +51,7 @@ def plot_data(column, i, title):
     ax.xaxis.set_major_formatter(LongitudeFormatter())
     ax.yaxis.set_major_formatter(LatitudeFormatter())
     # Set the plot region to be tight around the data
-    ax.set_extent(vd.get_region(data.longitude, data.latitude))
+    ax.set_extent(vd.get_region((data.longitude, data.latitude)))
     return mappable
 
 

--- a/examples/vector_trend.py
+++ b/examples/vector_trend.py
@@ -69,7 +69,7 @@ def plot_trend(ax, component, title):
     ax.xaxis.set_major_formatter(LongitudeFormatter())
     ax.yaxis.set_major_formatter(LatitudeFormatter())
     # ax.coastlines(color='white')
-    ax.set_extent(vd.get_region(data.longitude, data.latitude), crs=crs)
+    ax.set_extent(vd.get_region((data.longitude, data.latitude)), crs=crs)
 
 
 # Make a plot of the data using Cartopy to handle projections and coastlines

--- a/verde/base.py
+++ b/verde/base.py
@@ -219,7 +219,7 @@ class BaseGridder(BaseEstimator):
         if shape is None and spacing is None:
             shape = (101, 101)
         dims = get_dims(self, dims)
-        region = get_region(self, region)
+        region = get_instance_region(self, region)
         coordinates = grid_coordinates(region, shape=shape, spacing=spacing,
                                        adjust=adjust)
         if projection is None:
@@ -276,7 +276,7 @@ class BaseGridder(BaseEstimator):
 
         """
         dims = get_dims(self, dims)
-        region = get_region(self, region)
+        region = get_instance_region(self, region)
         coordinates = scatter_points(region, size, random_state)
         if projection is None:
             data = check_data(self.predict(coordinates))
@@ -410,7 +410,7 @@ def get_data_names(data, data_names):
     return data_types[len(data) - 1]
 
 
-def get_region(instance, region):
+def get_instance_region(instance, region):
     """
     Get the region attribute stored in instance if one is not provided.
     """

--- a/verde/chain.py
+++ b/verde/chain.py
@@ -79,7 +79,7 @@ class Chain(BaseGridder):
             Returns this estimator instance for chaining operations.
 
         """
-        self.region_ = get_region(*coordinates[:2])
+        self.region_ = get_region(coordinates[:2])
         residuals = data
         for _, step in self.steps:
             step.fit(coordinates, residuals, weights)

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -36,16 +36,16 @@ def check_region(region):
                          .format(region))
 
 
-def get_region(easting, northing):
+def get_region(coordinates):
     """
     Get the bounding region of the given coordinates.
 
     Parameters
     ----------
-    easting : array
-        The values of the West-East coordinates of each data point.
-    northing : array
-        The values of the South-North coordinates of each data point.
+    coordinates : tuple of arrays
+        Arrays with the coordinates of each data point. Should be in the
+        following order: (easting, northing, vertical, ...). Only easting and
+        northing will be used, all subsequent coordinates will be ignored.
 
     Returns
     -------
@@ -56,11 +56,12 @@ def get_region(easting, northing):
     Examples
     --------
 
-    >>> east, north = grid_coordinates((0, 1, -10, -6), shape=(10, 10))
-    >>> print(get_region(east, north))
+    >>> coords = grid_coordinates((0, 1, -10, -6), shape=(10, 10))
+    >>> print(get_region(coords))
     (0.0, 1.0, -10.0, -6.0)
 
     """
+    easting, northing = coordinates[:2]
     region = (np.min(easting), np.max(easting),
               np.min(northing), np.max(northing))
     return region
@@ -423,7 +424,7 @@ def profile_coordinates(point1, point2, size, coordinate_system='cartesian'):
     return easting, northing, distances
 
 
-def inside(easting, northing, region, out=None, tmp=None):
+def inside(coordinates, region, out=None, tmp=None):
     """
     Determine which points fall inside a given region.
 
@@ -431,10 +432,10 @@ def inside(easting, northing, region, out=None, tmp=None):
 
     Parameters
     ----------
-    easting : array
-        The values of the West-East coordinates of each data point.
-    northing : array
-        The values of the South-North coordinates of each data point.
+    coordinates : tuple of arrays
+        Arrays with the coordinates of each data point. Should be in the
+        following order: (easting, northing, vertical, ...). Only easting and
+        northing will be used, all subsequent coordinates will be ignored.
     region : list = [W, E, S, N]
         The boundaries of a given region in Cartesian or geographic
         coordinates.
@@ -462,7 +463,7 @@ def inside(easting, northing, region, out=None, tmp=None):
     >>> east = np.array([1, 2, 3, 4, 5, 6])
     >>> north = np.array([10, 11, 12, 13, 14, 15])
     >>> region = [2.5, 5.5, 12, 15]
-    >>> print(inside(east, north, region))
+    >>> print(inside((east, north), region))
     [False False  True  True  True False]
     >>> # This also works for 2D-arrays
     >>> east = np.array([[1, 1, 1],
@@ -472,7 +473,7 @@ def inside(easting, northing, region, out=None, tmp=None):
     ...                   [5, 7, 9],
     ...                   [5, 7, 9]])
     >>> region = [0.5, 2.5, 6, 9]
-    >>> print(inside(east, north, region))
+    >>> print(inside((east, north), region))
     [[False  True  True]
      [False  True  True]
      [False False False]]
@@ -480,6 +481,7 @@ def inside(easting, northing, region, out=None, tmp=None):
     """
     check_region(region)
     w, e, s, n = region
+    easting, northing = coordinates[:2]
     # Allocate temporary arrays to minimize memory allocation overhead
     if out is None:
         out = np.empty_like(easting, dtype=np.bool)

--- a/verde/scipy_bridge.py
+++ b/verde/scipy_bridge.py
@@ -98,7 +98,7 @@ class ScipyGridder(BaseGridder):
         coordinates, data, weights = check_fit_input(coordinates, data,
                                                      weights)
         easting, northing = coordinates[:2]
-        self.region_ = get_region(easting, northing)
+        self.region_ = get_region((easting, northing))
         points = np.column_stack((np.ravel(easting), np.ravel(northing)))
         self.interpolator_ = classes[self.method](points, np.ravel(data),
                                                   **kwargs)

--- a/verde/tests/test_base.py
+++ b/verde/tests/test_base.py
@@ -6,8 +6,8 @@ import pytest
 import numpy as np
 import numpy.testing as npt
 
-from ..base import get_dims, get_data_names, get_region, BaseGridder, \
-    check_fit_input
+from ..base import get_dims, get_data_names, get_instance_region, \
+    BaseGridder, check_fit_input
 from ..coordinates import grid_coordinates, scatter_points
 
 
@@ -70,15 +70,15 @@ def test_get_data_names_fails():
         get_data_names(tuple([np.arange(5)]*2), data_names=("meh",))
 
 
-def test_get_region():
-    "Check if get_region finds the correct region"
+def test_get_instance_region():
+    "Check if get_instance_region finds the correct region"
     grd = BaseGridder()
-    assert get_region(grd, region=(1, 2, 3, 4)) == (1, 2, 3, 4)
+    assert get_instance_region(grd, region=(1, 2, 3, 4)) == (1, 2, 3, 4)
     with pytest.raises(ValueError):
-        get_region(grd, region=None)
+        get_instance_region(grd, region=None)
     grd.region_ = (5, 6, 7, 8)
-    assert get_region(grd, region=None) == (5, 6, 7, 8)
-    assert get_region(grd, region=(1, 2, 3, 4)) == (1, 2, 3, 4)
+    assert get_instance_region(grd, region=None) == (5, 6, 7, 8)
+    assert get_instance_region(grd, region=(1, 2, 3, 4)) == (1, 2, 3, 4)
 
 
 class PolyGridder(BaseGridder):

--- a/verde/tests/test_grid_math.py
+++ b/verde/tests/test_grid_math.py
@@ -13,12 +13,14 @@ def test_block_reduce():
     region = (-5, 0, 5, 10)
     east, north = grid_coordinates(region, spacing=0.1, pixel_register=True)
     data = 20*np.ones_like(east)
-    re_east, re_north, re_data = block_reduce(
-        east, north, data, np.mean, spacing=1)
-    assert len(re_east) == len(re_north) == len(re_data) == 25
-    npt.assert_allclose(re_data, 20)
-    npt.assert_allclose(re_east[:5], np.linspace(-4.5, -0.5, 5))
-    npt.assert_allclose(re_north[::5], np.linspace(5.5, 9.5, 5))
+    block_coords, block_data = block_reduce((east, north), data, np.mean,
+                                            spacing=1)
+    assert len(block_coords[0]) == 25
+    assert len(block_coords[1]) == 25
+    assert len(block_data) == 25
+    npt.assert_allclose(block_data, 20)
+    npt.assert_allclose(block_coords[0][:5], np.linspace(-4.5, -0.5, 5))
+    npt.assert_allclose(block_coords[1][::5], np.linspace(5.5, 9.5, 5))
 
 
 def test_block_reduce_scatter():
@@ -26,10 +28,12 @@ def test_block_reduce_scatter():
     region = (-5, 0, 5, 10)
     east, north = scatter_points(region, size=10000, random_state=0)
     data = 20*np.ones_like(east)
-    re_east, re_north, re_data = block_reduce(
-        east, north, data, np.mean, spacing=1, region=region,
-        center_coordinates=True)
-    assert len(re_east) == len(re_north) == len(re_data) == 25
-    npt.assert_allclose(re_data, 20)
-    npt.assert_allclose(re_east[:5], np.linspace(-4.5, -0.5, 5))
-    npt.assert_allclose(re_north[::5], np.linspace(5.5, 9.5, 5))
+    block_coords, block_data = block_reduce((east, north), data, np.mean,
+                                            spacing=1, region=region,
+                                            center_coordinates=True)
+    assert len(block_coords[0]) == 25
+    assert len(block_coords[1]) == 25
+    assert len(block_data) == 25
+    npt.assert_allclose(block_data, 20)
+    npt.assert_allclose(block_coords[0][:5], np.linspace(-4.5, -0.5, 5))
+    npt.assert_allclose(block_coords[1][::5], np.linspace(5.5, 9.5, 5))

--- a/verde/tests/test_trend.py
+++ b/verde/tests/test_trend.py
@@ -73,7 +73,7 @@ def test_trend_jacobian_fails():
     "Test failing conditions for the trend jacobian builder"
     east, north = np.arange(50), np.arange(30)
     with pytest.raises(ValueError):
-        trend_jacobian(east, north, degree=1)
+        trend_jacobian((east, north), degree=1)
 
 
 def test_vector_trend(simple_2d_model):


### PR DESCRIPTION
Some functions where using `easting, northing` as input. I changed all
of them to take in a `coordinates` tuple instead. Now everything takes
it and uses the first 2 elements. Return values are also grouped into 
coordinates tuples.