### PR TITLE
BaseGridder.filter method for use in Chain

### DIFF
--- a/examples/data/synthetic_checkerboard.py
+++ b/examples/data/synthetic_checkerboard.py
@@ -3,18 +3,18 @@ Checkerboard function
 =====================
 
 The :class:`verde.datasets.CheckerBoard` class generates synthetic data in a
-checkerboard pattern. Use it like any gridder class.
+checkerboard pattern. It has the same data generation methods that most
+gridders have: predict, grid, scatter, and profile.
 """
 import matplotlib.pyplot as plt
 import verde as vd
 
 # Instantiate the data generator class and fit it to set the data region.
-synth = vd.datasets.CheckerBoard().fit()
+synth = vd.datasets.CheckerBoard()
 
-# Default values are provided for the region and the wavelengths of the
-# function (these are determined from the region).
-print("region:", synth.region_)
-print("wavelengths (east, north):", synth.w_east, synth.w_north)
+# Default values are provided for the wavelengths of the function determined
+# from the region.
+print("wavelengths (east, north):", synth.w_east_, synth.w_north_)
 
 # The CheckerBoard class behaves like any gridder class
 print("Checkerboard value at (easting=2000, northing=-2500):",

--- a/verde/scipy_bridge.py
+++ b/verde/scipy_bridge.py
@@ -40,8 +40,6 @@ class ScipyGridder(BaseGridder):
         interpolator. Used as the default region for the
         :meth:`~verde.ScipyGridder.grid` and
         :meth:`~verde.ScipyGridder.scatter` methods.
-    residual_ : array
-        The difference between the input data and the interpolated values.
 
     """
 
@@ -102,7 +100,6 @@ class ScipyGridder(BaseGridder):
         points = np.column_stack((np.ravel(easting), np.ravel(northing)))
         self.interpolator_ = classes[self.method](points, np.ravel(data),
                                                   **kwargs)
-        self.residual_ = data - self.predict(coordinates)
         return self
 
     def predict(self, coordinates):

--- a/verde/spline.py
+++ b/verde/spline.py
@@ -77,8 +77,6 @@ class Spline(BaseGridder):
         The boundaries (``[W, E, S, N]``) of the data used to fit the
         interpolator. Used as the default region for the
         :meth:`~verde.Spline.grid` and :meth:`~verde.Spline.scatter` methods.
-    residual_ : array
-        The difference between the input data and the predicted spline values.
 
     See also
     --------
@@ -146,7 +144,6 @@ class Spline(BaseGridder):
             regr = Ridge(alpha=self.damping, fit_intercept=False,
                          normalize=False)
         regr.fit(jac, data.ravel(), sample_weight=weights)
-        self.residual_ = data - jac.dot(regr.coef_).reshape(data.shape)
         self.force_ = regr.coef_/scaler.scale_
         return self
 

--- a/verde/tests/test_base.py
+++ b/verde/tests/test_base.py
@@ -87,7 +87,7 @@ class PolyGridder(BaseGridder):
     def __init__(self, degree=1):
         self.degree = degree
 
-    def fit(self, coordinates, data):
+    def fit(self, coordinates, data, weights=None):
         "Fit an easting polynomial"
         ndata = data.size
         nparams = self.degree + 1
@@ -107,7 +107,9 @@ def test_basegridder():
     "Test basic functionality of BaseGridder"
 
     with pytest.raises(NotImplementedError):
-        BaseGridder().predict((None, None))
+        BaseGridder().predict(None)
+    with pytest.raises(NotImplementedError):
+        BaseGridder().fit(None, None)
 
     grd = PolyGridder()
     assert repr(grd) == 'PolyGridder(degree=1)'

--- a/verde/tests/test_chain.py
+++ b/verde/tests/test_chain.py
@@ -6,14 +6,15 @@ import numpy.testing as npt
 from ..datasets.synthetic import CheckerBoard
 from ..chain import Chain
 from ..scipy_bridge import ScipyGridder
+from ..spline import Spline
 from ..trend import Trend
 
 
 def test_chain():
     "Test chaining trend and gridder."
     region = (1000, 5000, -8000, -7000)
-    synth = CheckerBoard(amplitude=100, w_east=1000, w_north=100)
-    synth.fit(region=region)
+    synth = CheckerBoard(amplitude=100, region=region, w_east=1000,
+                         w_north=100)
     data = synth.scatter(size=5000, random_state=0)
     east, north = coords = data.easting, data.northing
     coefs = [1000, 0.2, -1.4]
@@ -25,7 +26,7 @@ def test_chain():
     grd.fit(coords, all_data)
 
     npt.assert_allclose(grd.predict(coords), all_data)
-    npt.assert_allclose(grd.residual_, 0, atol=1e-5)
+    npt.assert_allclose(grd.score(coords, all_data), 1)
     npt.assert_allclose(grd.named_steps['trend'].coef_, coefs, rtol=1e-2)
     npt.assert_allclose(grd.named_steps['trend'].predict(coords), trend,
                         rtol=1e-3)
@@ -33,3 +34,21 @@ def test_chain():
     # this will work.
     # npt.assert_allclose(grd.named_steps['gridder'].predict(coords),
     #                     data.scalars, rtol=5e-2, atol=0.5)
+
+
+def test_chain_double():
+    "Test chaining a chain."
+    region = (1000, 5000, -8000, -7000)
+    synth = CheckerBoard(amplitude=100, region=region)
+    data = synth.scatter(size=1000, random_state=0)
+    east, north = coords = data.easting, data.northing
+    coefs = [-5000, -0.2, 1.4]
+    trend = coefs[0] + coefs[1]*east + coefs[2]*north
+    all_data = trend + data.scalars
+
+    grd = Chain([('trend', Trend(degree=1)),
+                 ('gridder', Chain([('spline', Spline())]))])
+    grd.fit(coords, all_data)
+
+    npt.assert_allclose(grd.predict(coords), all_data)
+    npt.assert_allclose(grd.score(coords, all_data), 1)

--- a/verde/tests/test_scipy.py
+++ b/verde/tests/test_scipy.py
@@ -16,7 +16,7 @@ from ..datasets.synthetic import CheckerBoard
 def test_scipy_gridder_same_points():
     "See if the gridder recovers known points."
     region = (1000, 5000, -8000, -7000)
-    synth = CheckerBoard().fit(region=region)
+    synth = CheckerBoard(region=region)
     data = synth.scatter(size=1000, random_state=0)
     coords = (data.easting, data.northing)
     # The interpolation should be perfect on top of the data points
@@ -25,13 +25,12 @@ def test_scipy_gridder_same_points():
         grd.fit(coords, data.scalars)
         predicted = grd.predict(coords)
         npt.assert_allclose(predicted, data.scalars)
-        npt.assert_allclose(grd.residual_, 0, atol=1e-5)
         npt.assert_allclose(grd.score(coords, data.scalars), 1)
 
 
 def test_scipy_gridder():
     "See if the gridder recovers known points."
-    synth = CheckerBoard().fit(region=(1000, 5000, -8000, -6000))
+    synth = CheckerBoard(region=(1000, 5000, -8000, -6000))
     data = synth.scatter(size=20000, random_state=0)
     coords = (data.easting, data.northing)
     pt_coords = (3000, -7000)
@@ -46,7 +45,7 @@ def test_scipy_gridder():
 def test_scipy_gridder_region():
     "See if the region is gotten from the data is correct."
     region = (1000, 5000, -8000, -6000)
-    synth = CheckerBoard().fit(region=region)
+    synth = CheckerBoard(region=region)
     # Test using xarray objects
     grid = synth.grid()
     coords = grid_coordinates(region, grid.scalars.shape)
@@ -62,7 +61,7 @@ def test_scipy_gridder_region():
 
 def test_scipy_gridder_extra_args():
     "Passing in extra arguments to scipy"
-    data = CheckerBoard().fit().scatter(random_state=100)
+    data = CheckerBoard().scatter(random_state=100)
     coords = (data.easting, data.northing)
     grd = ScipyGridder(method='linear', extra_args=dict(rescale=True))
     grd.fit(coords, data.scalars)
@@ -72,7 +71,7 @@ def test_scipy_gridder_extra_args():
 
 def test_scipy_gridder_fails():
     "fit should fail for invalid method name"
-    data = CheckerBoard().fit().scatter(random_state=0)
+    data = CheckerBoard().scatter(random_state=0)
     grd = ScipyGridder(method='some invalid method name')
     with pytest.raises(ValueError):
         grd.fit((data.easting, data.northing), data.scalars)
@@ -80,7 +79,7 @@ def test_scipy_gridder_fails():
 
 def test_scipy_gridder_warns():
     "Check that a warning is issued when using weights."
-    data = CheckerBoard().fit().scatter(random_state=100)
+    data = CheckerBoard().scatter(random_state=100)
     weights = np.ones_like(data.scalars)
     grd = ScipyGridder()
     msg = "ScipyGridder does not support weights and they will be ignored."

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -13,13 +13,12 @@ from ..datasets.synthetic import CheckerBoard
 def test_spline():
     "See if the exact spline solution."
     region = (100, 500, -800, -700)
-    synth = CheckerBoard().fit(region=region)
+    synth = CheckerBoard(region=region)
     data = synth.scatter(size=1500, random_state=1)
     coords = (data.easting, data.northing)
     # The interpolation should be perfect on top of the data points
     spline = Spline().fit(coords, data.scalars)
     npt.assert_allclose(spline.predict(coords), data.scalars, rtol=1e-5)
-    npt.assert_allclose(spline.residual_, 0, atol=1e-5)
     npt.assert_allclose(spline.score(coords, data.scalars), 1)
     # There should be 1 force per data point
     assert data.scalars.size == spline.force_.size
@@ -36,7 +35,7 @@ def test_spline():
 def test_spline_region():
     "See if the region is gotten from the data is correct."
     region = (1000, 5000, -8000, -6000)
-    grid = CheckerBoard().fit(region=region).grid(shape=(10, 10))
+    grid = CheckerBoard(region=region).grid(shape=(10, 10))
     coords = np.meshgrid(grid.easting, grid.northing)
     grd = Spline().fit(coords, grid.scalars.values)
     npt.assert_allclose(grd.region_, region)
@@ -45,13 +44,12 @@ def test_spline_region():
 def test_spline_damping():
     "Test the spline solution with a bit of damping"
     region = (100, 500, -800, -700)
-    synth = CheckerBoard().fit(region=region)
+    synth = CheckerBoard(region=region)
     data = synth.scatter(size=1200, random_state=1)
     coords = (data.easting, data.northing)
     # The interpolation should be close on top of the data points
     spline = Spline(damping=1e-15).fit(coords, data.scalars)
-    npt.assert_allclose(spline.residual_.mean(), 0, atol=1e-2)
-    npt.assert_allclose(spline.residual_.std(), 0, atol=1e-2)
+    npt.assert_allclose(spline.predict(coords), data.scalars, rtol=1e-5)
     shape = (5, 5)
     region = (270, 320, -770, -720)
     # Tolerance needs to be kind of high to allow for error due to small
@@ -64,13 +62,12 @@ def test_spline_damping():
 def test_spline_grid():
     "Test the spline solution with forces on a grid"
     region = (1000, 5000, -8000, -7000)
-    synth = CheckerBoard().fit(region=region)
+    synth = CheckerBoard(region=region)
     data = synth.scatter(size=1500, random_state=1)
     coords = (data.easting, data.northing)
     # The interpolation should be close on top of the data points
     spline = Spline(shape=(35, 35)).fit(coords, data.scalars)
-    npt.assert_allclose(spline.residual_.mean(), 0, atol=1e-2)
-    npt.assert_allclose(spline.residual_.std(), 0, atol=2)
+    npt.assert_allclose(spline.score(coords, data.scalars), 1, rtol=1e-2)
     assert spline.force_.size == 35**2
     shape = (3, 3)
     region = (2700, 3200, -7700, -7200)
@@ -83,7 +80,7 @@ def test_spline_grid():
 
 def test_spline_warns():
     "Check that a warning is issued when using weights and the exact solution."
-    data = CheckerBoard().fit().scatter(random_state=100)
+    data = CheckerBoard().scatter(random_state=100)
     weights = np.ones_like(data.scalars)
     grd = Spline()
     msg = "Weights are ignored for the exact spline solution"

--- a/verde/tests/test_trend.py
+++ b/verde/tests/test_trend.py
@@ -44,7 +44,6 @@ def test_trend(simple_model):
     trend = Trend(degree=1).fit(coords, data)
     npt.assert_allclose(trend.coef_, coefs)
     npt.assert_allclose(trend.predict(coords), data)
-    npt.assert_allclose(trend.residual_, 0, atol=1e-5)
 
 
 def test_trend_weights(simple_model):
@@ -57,7 +56,7 @@ def test_trend_weights(simple_model):
     weights[20, 20] = 1e-10
     trend = Trend(degree=1).fit(coords, data_out, weights)
     npt.assert_allclose(trend.coef_, coefs)
-    npt.assert_allclose(trend.residual_[20, 20], outlier)
+    npt.assert_allclose((data_out - trend.predict(coords))[20, 20], outlier)
     npt.assert_allclose(trend.predict(coords), data)
 
 
@@ -83,7 +82,6 @@ def test_vector_trend(simple_2d_model):
     for i, coef in enumerate(coefs):
         npt.assert_allclose(trend.component_[i].coef_, coef)
         npt.assert_allclose(trend.predict(coords)[i], data[i])
-        npt.assert_allclose(trend.residual_[i], 0, atol=1e-5)
         npt.assert_allclose(trend.score(coords, data), 1)
 
 
@@ -94,7 +92,6 @@ def test_vector_trend_3d(simple_3d_model):
     for i, coef in enumerate(coefs):
         npt.assert_allclose(trend.component_[i].coef_, coef)
         npt.assert_allclose(trend.predict(coords)[i], data[i])
-        npt.assert_allclose(trend.residual_[i], 0, atol=1e-5)
         npt.assert_allclose(trend.score(coords, data), 1)
 
 
@@ -120,5 +117,6 @@ def test_vector_trend_weights(simple_2d_model):
     trend = VectorTrend(degree=1).fit(coords, data_out, weights)
     for i, coef in enumerate(coefs):
         npt.assert_allclose(trend.component_[i].coef_, coef)
-        npt.assert_allclose(trend.residual_[i][20, 20], outlier)
+        npt.assert_allclose((data_out[i] - trend.predict(coords)[i])[20, 20],
+                            outlier)
         npt.assert_allclose(trend.predict(coords)[i], data[i])


### PR DESCRIPTION
Instead of relying on the `residual_` argument, implement a new `filter`
method in the `BaseGridder` that fits a model and returns the
coordinates, residuals, and weights. This can be used by `Chain` to
chain the estimators. The advantage of not relying on `fit` and
`predict` is that other operations like `block_reduce` can be used with
it (didn't fit the old model because it changes the coordinates as well).
