### PR TITLE
Linkcheck the API docs as well

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -30,6 +30,12 @@ clean:
 	rm -rf sample_data
 	rm -rf .ipynb_checkpoints
 
+api:
+	@echo
+	@echo "Building API docs."
+	@echo
+	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/index.rst ../examples-data/README.txt
+
 html: api
 	@echo
 	@echo "Building HTML files."
@@ -38,14 +44,7 @@ html: api
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-api:
-	@echo
-	@echo "Building API docs."
-	@echo
-	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/index.rst ../examples-data/README.txt
-
-
-linkcheck:
+linkcheck: api
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \


### PR DESCRIPTION
Need to build the API before running linkcheck to make sure that
automodule was run. Otherwise the API docs don't get checked.