### PR TITLE
Enable OSX and Windows CI builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,6 +37,8 @@ install:
     - cmd: continuous-integration\appveyor\setup-miniconda.bat
     # Activate the new environment
     - cmd: activate testing
+    # Update pip to the latest version
+    - cmd: pip install --upgrade pip
     # Show installed pkg information for postmortem diagnostic
     - cmd: conda list
     # Make a source package for the project and install it

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,8 +37,6 @@ install:
     - cmd: continuous-integration\appveyor\setup-miniconda.bat
     # Activate the new environment
     - cmd: activate testing
-    # Update pip to the latest version
-    - cmd: python -m pip install --upgrade pip
     # Show installed pkg information for postmortem diagnostic
     - cmd: conda list
     # Make a source package for the project and install it

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,17 +10,16 @@ branches:
 
 environment:
     matrix:
-        # Python 3.5, 32 and 64 bit
-        - MINICONDA: C:\Miniconda35
-          PYTHON: 3.5
-
+        # Python 3.5 32bit
+        #- MINICONDA: C:\Miniconda35
+          #PYTHON: 3.5
+        # Python 3.5 64bit
         - MINICONDA: C:\Miniconda35-x64
           PYTHON: 3.5
-
-        # Python 3.6, 32 and 64 bit
-        - MINICONDA: C:\Miniconda36
-          PYTHON: 3.6
-
+        # Python 3.6 32bit
+        #- MINICONDA: C:\Miniconda36
+          #PYTHON: 3.6
+        # Python 3.6 64bit
         - MINICONDA: C:\Miniconda36-x64
           PYTHON: 3.6
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,7 +38,7 @@ install:
     # Activate the new environment
     - cmd: activate testing
     # Update pip to the latest version
-    - cmd: pip install --upgrade pip
+    - cmd: python -m pip install --upgrade pip
     # Show installed pkg information for postmortem diagnostic
     - cmd: conda list
     # Make a source package for the project and install it

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,50 @@
+# Continuous integration for Windows using http://appveyor.com/
+
+# Not a .NET project, we build ci-helpers in the install step instead
+build: false
+
+# Only build pushes to the master branch. Will still build tags and pull requests.
+branches:
+    only:
+        - master
+
+environment:
+    matrix:
+        # Python 3.5, 32 and 64 bit
+        - MINICONDA: C:\Miniconda35
+          PYTHON: 3.5
+
+        - MINICONDA: C:\Miniconda35-x64
+          PYTHON: 3.5
+
+        # Python 3.6, 32 and 64 bit
+        - MINICONDA: C:\Miniconda36
+          PYTHON: 3.6
+
+        - MINICONDA: C:\Miniconda36-x64
+          PYTHON: 3.6
+
+init:
+    # Add miniconda to the PATH
+    - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%"
+    # The file with the listed requirements to be installed by setup-miniconda.bat
+    - set CONDA_REQUIREMENTS=requirements.txt
+
+install:
+    # Get the Fatiando CI scripts
+    - cmd: git clone https://github.com/fatiando/continuous-integration.git
+    # Setup miniconda and install the requirements into a new environment
+    - cmd: continuous-integration\appveyor\setup-miniconda.bat
+    # Activate the new environment
+    - cmd: activate testing
+    # Show installed pkg information for postmortem diagnostic
+    - cmd: conda list
+    # Make a source package for the project and install it
+    - cmd: python setup.py sdist --formats=zip
+    - ps: ls dist
+    - ps: pip install --no-deps (Get-ChildItem dist\*.zip)
+
+
+test_script:
+    # Run the tests inside a tmp folder to make sure we're testing the installed version
+    - ps: mkdir -p tmp; cd tmp; python -c "import verde; verde.test()"

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,14 @@ matrix:
               - LINKCHECK=true
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
+        - os: osx
+          env:
+              - PYTHON=3.5
+        - os: osx
+          env:
+              - PYTHON=3.6
+              - COVERAGE=true
+              - BUILD_DOCS=true
 
 # Setup the build environment
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,12 @@ env:
         # PyPI password for deploying releases (TWINE_PASSWORD)
         - secure: "Gvd2kH5bGIng7Wz3R4Md5d48qU0vYo0Sb4g7A1UAn8EOuWAcbkdSAq5yDiAp4pENeGceHQG0+jX+GQBZoSOMUpwAfhPkWG5HBIc+P/G+iTUyF2oELLCekcGgccPzwNgQt574FzM0PkC9L4hINNRjVtnFa+SIx72D2r1OdTvmk2+c4jXBZl52e4l5dU+Hjzwh22KNzAMtXDVuvr3NVdJZHA/ldTwEBUQfiLo2CGkgls6o8ZLixK0tCRGIFKlZko9WeBTzQYidloSo3EQx0eqiTz7qydm3UfCezA9UYPefGOtUaA/4ysqs8tgG8xrnx8NhhRqH9pfPAhgsCMwfmtibslNwH+C7gtbERT8lLY5NfU1xyDC4UxkjbwbzKQno/vPhiqEJ/uR458IdZbzUeWXlt+Rz+Dyj1lW7FqPLOl3Zpfgfv1swWqxjVwduV46c3nlgu9fEkAiEH2SzAtBlsQ2qwbJCZKXj+8Ps9FmaqvQ+SCOTAycgR9WnYoIIutpn0cs3k8zqqQyBq2zXJLkPHflVich8wKKaOsaFMCIKLWaOODCw5fLkfxck/QtlolGGFi3lh5W5p4Zxxr7KdL8f+UrkAb6gY9LStvqwe2rSG2olqc95+zozsMY/YHXTIG092WB3EmptwO9jL67D3AIVBKOdvcRYFetWMyY61ZmEK0s/43I="
         - TWINE_USERNAME=Leonardo.Uieda
-        #
         # The file with the listed requirements to be installed by conda
         - CONDA_REQUIREMENTS=requirements.txt
-        #
         # These variables control which actions are performed in a build
         - COVERAGE=false
         - BUILD_DOCS=false
+        - CHECK_FORMAT=false
         - LINKCHECK=false
         - DEPLOY_DOCS=false
         - DEPLOY_PYPI=false
@@ -39,22 +38,25 @@ matrix:
     include:
         - os: linux
           env:
-              - PYTHON=3.5
-        - os: linux
-          env:
               - PYTHON=3.6
+              - CHECK_FORMAT=true
               - COVERAGE=true
               - BUILD_DOCS=true
               - LINKCHECK=true
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
-        - os: osx
+        - os: linux
           env:
               - PYTHON=3.5
+              - BUILD_DOCS=true
         - os: osx
           env:
               - PYTHON=3.6
               - COVERAGE=true
+              - BUILD_DOCS=true
+        - os: osx
+          env:
+              - PYTHON=3.5
               - BUILD_DOCS=true
 
 # Setup the build environment
@@ -79,7 +81,9 @@ install:
 # Run the actual tests and checks
 script:
     # Check code for style and quality
-    - make check
+    - if [ "$CHECK_FORMAT" == "true" ]; then
+          make check;
+      fi
     # Run the test suite
     - if [ "$COVERAGE" == "true" ]; then
           pip install codecov;

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,8 @@
 
     <p align="center">
     <a href="https://pypi.python.org/pypi/verde"><img alt="Latest version on PyPI" src="http://img.shields.io/pypi/v/verde.svg?style=flat-square"></a>
-    <a href="https://travis-ci.org/fatiando/verde"><img alt="Travis CI build status" src="http://img.shields.io/travis/fatiando/verde/master.svg?style=flat-square&label=TravisCI"></a>
+    <a href="https://travis-ci.org/fatiando/verde"><img alt="TravisCI build status" src="http://img.shields.io/travis/fatiando/verde/master.svg?style=flat-square&label=Linux|Mac"></a>
+    <a href="https://ci.appveyor.com/project/fatiando/verde"><img alt="AppVeyor build status" src="http://img.shields.io/appveyor/ci/fatiando/verde/master.svg?style=flat-square&label=Windows"></a>
     <a href="https://codecov.io/gh/fatiando/verde"><img alt="Test coverage status" src="https://img.shields.io/codecov/c/github/fatiando/verde/master.svg?style=flat-square"></a>
     <a href="https://codeclimate.com/github/fatiando/verde"><img alt="Code quality status" src="https://img.shields.io/codeclimate/maintainability/fatiando/verde.svg?style=flat-square"></a>
     <a href="https://www.codacy.com/app/leouieda/verde"><img alt="Code quality grade on codacy" src="https://img.shields.io/codacy/grade/6b698defc0df47288a634930d41a9d65.svg?style=flat-square&label=codacy"></a>


### PR DESCRIPTION
AppVeyor runs builds for Python 3.5 and 3.6 on 64bit systems.