### PR TITLE
Use pykdtree if available in blockreduce and distance_mask

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -25,6 +25,7 @@ Dependencies
 * `xarray <http://xarray.pydata.org/>`__
 * `scikit-learn <http://scikit-learn.org/>`__
 * `requests <http://docs.python-requests.org/>`__
+* `pykdtree <https://github.com/storpipfugl/pykdtree>`__ (optional)
 
 Most of the examples in the :ref:`gallery` and :ref:`tutorials` also use:
 
@@ -33,6 +34,10 @@ Most of the examples in the :ref:`gallery` and :ref:`tutorials` also use:
 * `pyproj <https://jswhit.github.io/pyproj/>`__ for cartographic projections
 * `dask <https://dask.pydata.org/>`__ for parallelism
 
+.. note::
+
+    PyKDTree is an optional dependency and will be used instead of scipy's
+    cKDTree if available for better performance.
 
 Installing with conda
 ---------------------

--- a/verde/blockreduce.py
+++ b/verde/blockreduce.py
@@ -3,12 +3,16 @@ Classes for reducing/aggregating data in blocks.
 """
 import numpy as np
 import pandas as pd
-from scipy.spatial import cKDTree  # pylint: disable=no-name-in-module
 from sklearn.base import BaseEstimator
 
 from .coordinates import get_region, grid_coordinates
 from .base import check_fit_input
 from .utils import variance_to_weights
+
+try:
+    from pykdtree.kdtree import KDTree
+except ImportError:
+    from scipy.spatial import cKDTree as KDTree  # pylint: disable=no-name-in-module
 
 
 def block_split(coordinates, spacing, adjust="spacing", region=None):
@@ -68,6 +72,10 @@ def block_split(coordinates, spacing, adjust="spacing", region=None):
      [2 2 2 3 3 3]
      [2 2 2 3 3 3]]
 
+    .. note::
+
+        If available, `pykdtree` can be installed for better performance.
+
     """
     easting, northing = coordinates[:2]
     if region is None:
@@ -79,7 +87,7 @@ def block_split(coordinates, spacing, adjust="spacing", region=None):
         )
     )
     # The index of the block with the closest center to each data point
-    tree = cKDTree(np.transpose(block_coords))
+    tree = KDTree(np.transpose(block_coords))
     labels = tree.query(np.transpose((easting.ravel(), northing.ravel())))[1]
     return block_coords, labels
 

--- a/verde/grid_math.py
+++ b/verde/grid_math.py
@@ -2,9 +2,13 @@
 Operations on spatial data: block operations, derivatives, etc.
 """
 import numpy as np
-from scipy.spatial import cKDTree  # pylint: disable=no-name-in-module
 
 from .coordinates import grid_coordinates
+
+try:
+    from pykdtree.kdtree import KDTree
+except ImportError:
+    from scipy.spatial import cKDTree as KDTree  # pylint: disable=no-name-in-module
 
 
 def distance_mask(
@@ -80,6 +84,10 @@ def distance_mask(
      [False False False  True  True False]
      [False False False False False False]]
 
+    .. note::
+
+        If available, `pykdtree` can be installed for better performance.
+
     """
     if coordinates is None:
         if region is None:
@@ -95,7 +103,7 @@ def distance_mask(
     data_easting = np.atleast_1d(data_easting)
     data_northing = np.atleast_1d(data_northing)
     data_points = np.transpose((data_easting.ravel(), data_northing.ravel()))
-    tree = cKDTree(data_points)
+    tree = KDTree(data_points)
     points = np.transpose((easting.ravel(), northing.ravel()))
     distance = tree.query(points)[0].reshape(easting.shape)
     return distance <= maxdist


### PR DESCRIPTION
Adds optional 'pykdtree' dependency for blockreduce and grid_math modules for better performance on the associated operations. Include notes in the docstrings for these methods and in the install instructions.

Feel free to be picky about how things are worded 😉 I get it.

Fixes #90 