### PR TITLE
Only install black on Travis for 3.6 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,10 @@ before_install:
     # Download and install miniconda and setup dependencies
     # Need to source the script to set the PATH variable globaly
     - source continuous-integration/travis/setup-miniconda.sh
+    # Black is Python 3.6 only so it can't be in the requirements file.
+    - if [ "$CHECK_FORMAT" == "true" ]; then
+          conda install --yes --channel conda-forge black python=$PYTHON;
+      fi
     # Show installed pkg information for postmortem diagnostic
     - conda list
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ pytest
 pytest-cov
 pytest-mpl
 coverage
-black
 pylint
 sphinx
 sphinx_rtd_theme
@@ -22,3 +21,5 @@ sphinx-gallery
 nbsphinx
 numpydoc
 twine
+# Black is not included because it requires Python 3.6
+#black


### PR DESCRIPTION
Black is 3.6 only and was breaking the 3.5 build.
Remove it from `requirements.txt` and only install it if running the
code checks on 3.6 builds.

Fixes the CI failures in #92 
