### PR TITLE
Make the jacobian functions into class methods

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,6 +33,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "numpy": ("https://docs.scipy.org/doc/numpy/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "sklearn": ("http://scikit-learn.org/stable/", None),
     "pandas": ("http://pandas.pydata.org/pandas-docs/stable/", None),
     "xarray": ("http://xarray.pydata.org/en/stable/", None),
     "cartopy": ("https://scitools.org.uk/cartopy/docs/latest/", None),

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -16,12 +16,12 @@ from .grid_math import distance_mask
 from .utils import variance_to_weights, maxabs
 from .blockreduce import block_split, BlockReduce, BlockMean
 from .scipygridder import ScipyGridder
-from .trend import Trend, trend_jacobian
+from .trend import Trend
 from .chain import Chain
 from .components import Components
-from .spline import Spline, spline_jacobian
+from .spline import Spline
 from .model_selection import cross_val_score, train_test_split
-from .vector import Vector2D, vector2d_jacobian
+from .vector import Vector2D
 
 
 def test(doctest=True, verbose=True, coverage=False, figures=True):

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -34,6 +34,20 @@ def test_spline():
     )
 
 
+def test_spline_twice():
+    "Check that the forces are updated when fitting twice"
+    grid = CheckerBoard(region=(1000, 5000, -8000, -6000)).grid(shape=(10, 10))
+    coords = np.meshgrid(grid.easting, grid.northing)
+    spline = Spline()
+    spline.fit(coords, grid.scalars.values)
+    npt.assert_allclose(spline.force_coords_, coords)
+    grid2 = CheckerBoard(region=(-15, -5, 10, 20)).grid(shape=(10, 10))
+    coords2 = np.meshgrid(grid2.easting, grid2.northing)
+    spline.fit(coords2, grid2.scalars.values)
+    npt.assert_allclose(spline.force_coords_, coords2)
+    assert not np.allclose(spline.force_coords_, coords)
+
+
 def test_spline_region():
     "See if the region is gotten from the data is correct."
     region = (1000, 5000, -8000, -6000)

--- a/verde/tests/test_trend.py
+++ b/verde/tests/test_trend.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from ..trend import Trend, polynomial_power_combinations, trend_jacobian
+from ..trend import Trend, polynomial_power_combinations
 from ..coordinates import grid_coordinates
 
 
@@ -52,5 +52,6 @@ def test_polynomial_combinations_fails():
 def test_trend_jacobian_fails():
     "Test failing conditions for the trend jacobian builder"
     east, north = np.arange(50), np.arange(30)
+    trend = Trend(degree=1)
     with pytest.raises(ValueError):
-        trend_jacobian((east, north), degree=1)
+        trend.jacobian((east, north))

--- a/verde/tests/test_vector.py
+++ b/verde/tests/test_vector.py
@@ -32,6 +32,17 @@ def test_vector2d(data2d):
     npt.assert_allclose(spline.force_coords_, coords)
 
 
+def test_vector2d_twice(data2d):
+    "Check that the force coordinates are updated if fitting a second time"
+    coords, data = data2d
+    spline = Vector2D().fit(coords, data)
+    npt.assert_allclose(spline.force_coords_, coords)
+    coords2 = tuple(i * 1000 for i in coords)
+    spline.fit(coords2, data)
+    npt.assert_allclose(spline.force_coords_, coords2)
+    assert not np.allclose(spline.force_coords_, coords)
+
+
 def test_vector2d_weights(data2d):
     "Use unit weights and a regular grid solution"
     coords, data = data2d


### PR DESCRIPTION
`Trend`, `Spline`, and `Vector2D` defined the Jacobian matrix
calculations as separate functions. Make them methods of each class
instead.
For `Spline` and `Vector2D`, the `jacobian` method is now responsible
for picking the locations of the forces. Fitting twice will remove the
existing force locations and pick new ones.