### PR TITLE
Refactor block_split and move to coordinates module

### DIFF
--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -6,6 +6,7 @@ from .coordinates import (
     scatter_points,
     grid_coordinates,
     inside,
+    block_split,
     profile_coordinates,
     get_region,
     pad_region,
@@ -13,7 +14,7 @@ from .coordinates import (
 )
 from .mask import distance_mask
 from .utils import variance_to_weights, maxabs
-from .blockreduce import block_split, BlockReduce, BlockMean
+from .blockreduce import BlockReduce, BlockMean
 from .scipygridder import ScipyGridder
 from .trend import Trend
 from .chain import Chain

--- a/verde/base.py
+++ b/verde/base.py
@@ -12,6 +12,7 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.linear_model import LinearRegression, Ridge
 
 from .coordinates import grid_coordinates, profile_coordinates, scatter_points
+from .utils import check_data
 
 
 class BaseGridder(BaseEstimator):
@@ -550,24 +551,6 @@ def get_instance_region(instance, region):
             raise ValueError("No default region found. Argument must be supplied.")
         region = getattr(instance, "region_")
     return region
-
-
-def check_data(data):
-    """
-    Check the data returned by predict.
-    If the data is a single array, return it as a tuple with a single element.
-
-    Examples
-    --------
-
-    >>> check_data([1, 2, 3])
-    ([1, 2, 3],)
-    >>> check_data(([1, 2], [3, 4]))
-    ([1, 2], [3, 4])
-    """
-    if not isinstance(data, tuple):
-        data = (data,)
-    return data
 
 
 def check_fit_input(coordinates, data, weights, unpack=True):

--- a/verde/blockreduce.py
+++ b/verde/blockreduce.py
@@ -5,91 +5,9 @@ import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
 
-from .coordinates import get_region, grid_coordinates
+from .coordinates import block_split
 from .base import check_fit_input
 from .utils import variance_to_weights
-
-try:
-    from pykdtree.kdtree import KDTree
-except ImportError:
-    from scipy.spatial import cKDTree as KDTree  # pylint: disable=no-name-in-module
-
-
-def block_split(coordinates, spacing, adjust="spacing", region=None):
-    """
-    Split a region into blocks and label points according to where they fall.
-
-    The labels are integers corresponding to the index of the block. The same
-    index is used for the coordinates of each block.
-
-    Parameters
-    ----------
-    coordinates : tuple of arrays
-        Arrays with the coordinates of each data point. Should be in the
-        following order: (easting, northing, vertical, ...). Only easting and
-        northing will be used, all subsequent coordinates will be ignored.
-    spacing : float, tuple = (s_north, s_east), or None
-        The block size in the South-North and West-East directions,
-        respectively. A single value means that the size is equal in both
-        directions.
-    adjust : {'spacing', 'region'}
-        Whether to adjust the spacing or the region if required. Ignored if
-        *shape* is given instead of *spacing*. Defaults to adjusting the
-        spacing.
-    region : list = [W, E, S, N]
-        The boundaries of a given region in Cartesian or geographic
-        coordinates. If not region is given, will use the bounding region of
-        the given points.
-
-    Returns
-    -------
-    block_coordinates : tuple of arrays
-        (easting, northing) arrays with the coordinates of the center of each
-        block.
-    labels : array
-        integer label for each data point. The label is the index of the block
-        to which that point belongs.
-
-    See also
-    --------
-    BlockReduce : Apply a reduction operation to the data in blocks (windows).
-
-    Examples
-    --------
-
-    >>> from verde import grid_coordinates
-    >>> coords = grid_coordinates((-5, 0, 5, 10), spacing=1)
-    >>> block_coords, labels = block_split(coords, spacing=2.5)
-    >>> for coord in block_coords:
-    ...     print(', '.join(['{:.2f}'.format(i) for i in coord]))
-    -3.75, -1.25, -3.75, -1.25
-    6.25, 6.25, 8.75, 8.75
-    >>> print(labels.reshape(coords[0].shape))
-    [[0 0 0 1 1 1]
-     [0 0 0 1 1 1]
-     [0 0 0 1 1 1]
-     [2 2 2 3 3 3]
-     [2 2 2 3 3 3]
-     [2 2 2 3 3 3]]
-
-    .. note::
-
-        If available, `pykdtree` can be installed for better performance.
-
-    """
-    easting, northing = coordinates[:2]
-    if region is None:
-        region = get_region((easting, northing))
-    block_coords = tuple(
-        i.ravel()
-        for i in grid_coordinates(
-            region, spacing=spacing, adjust=adjust, pixel_register=True
-        )
-    )
-    # The index of the block with the closest center to each data point
-    tree = KDTree(np.transpose(block_coords))
-    labels = tree.query(np.transpose((easting.ravel(), northing.ravel())))[1]
-    return block_coords, labels
 
 
 def attach_weights(reduction, weights):

--- a/verde/chain.py
+++ b/verde/chain.py
@@ -3,7 +3,8 @@ Class for chaining gridders.
 """
 from sklearn.utils.validation import check_is_fitted
 
-from .base import BaseGridder, check_data
+from .base import BaseGridder
+from .utils import check_data
 from .coordinates import get_region
 
 

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -4,6 +4,13 @@ Functions for generating and manipulating coordinates.
 import numpy as np
 from sklearn.utils import check_random_state
 
+try:
+    from pykdtree.kdtree import KDTree
+except ImportError:
+    from scipy.spatial import cKDTree as KDTree  # pylint: disable=no-name-in-module
+
+from .utils import n_1d_arrays
+
 
 def check_region(region):
     """
@@ -575,3 +582,79 @@ def inside(coordinates, region, out=None, tmp=None):
     )
     are_inside = np.logical_and(in_we, in_ns, out=out)
     return are_inside
+
+
+def block_split(coordinates, spacing, adjust="spacing", region=None):
+    """
+    Split a region into blocks and label points according to where they fall.
+
+    The labels are integers corresponding to the index of the block. The same
+    index is used for the coordinates of each block.
+
+    .. note::
+
+        If installed, package ``pykdtree`` will be used instead of
+        :class:`scipy.spatial.cKDTree` for better performance.
+
+    Parameters
+    ----------
+    coordinates : tuple of arrays
+        Arrays with the coordinates of each data point. Should be in the
+        following order: (easting, northing, vertical, ...). Only easting and
+        northing will be used, all subsequent coordinates will be ignored.
+    spacing : float, tuple = (s_north, s_east), or None
+        The block size in the South-North and West-East directions,
+        respectively. A single value means that the size is equal in both
+        directions.
+    adjust : {'spacing', 'region'}
+        Whether to adjust the spacing or the region if required. Ignored if
+        *shape* is given instead of *spacing*. Defaults to adjusting the
+        spacing.
+    region : list = [W, E, S, N]
+        The boundaries of a given region in Cartesian or geographic
+        coordinates. If not region is given, will use the bounding region of
+        the given points.
+
+    Returns
+    -------
+    block_coordinates : tuple of arrays
+        (easting, northing) arrays with the coordinates of the center of each
+        block.
+    labels : array
+        integer label for each data point. The label is the index of the block
+        to which that point belongs.
+
+    See also
+    --------
+    BlockReduce : Apply a reduction operation to the data in blocks (windows).
+
+    Examples
+    --------
+
+    >>> from verde import grid_coordinates
+    >>> coords = grid_coordinates((-5, 0, 5, 10), spacing=1)
+    >>> block_coords, labels = block_split(coords, spacing=2.5)
+    >>> for coord in block_coords:
+    ...     print(', '.join(['{:.2f}'.format(i) for i in coord]))
+    -3.75, -1.25, -3.75, -1.25
+    6.25, 6.25, 8.75, 8.75
+    >>> print(labels.reshape(coords[0].shape))
+    [[0 0 0 1 1 1]
+     [0 0 0 1 1 1]
+     [0 0 0 1 1 1]
+     [2 2 2 3 3 3]
+     [2 2 2 3 3 3]
+     [2 2 2 3 3 3]]
+
+    """
+    if region is None:
+        region = get_region(coordinates)
+    block_coords = tuple(
+        i.ravel()
+        for i in grid_coordinates(
+            region, spacing=spacing, adjust=adjust, pixel_register=True
+        )
+    )
+    tree = KDTree(np.transpose(block_coords))
+    labels = tree.query(np.transpose(n_1d_arrays(coordinates, 2)))[1]
+    return block_coords, labels

--- a/verde/utils.py
+++ b/verde/utils.py
@@ -5,8 +5,6 @@ import functools
 
 import numpy as np
 
-from .base import check_data
-
 
 def parse_engine(engine):
     """
@@ -94,6 +92,27 @@ def n_1d_arrays(arrays, n):
 
     """
     return tuple(np.atleast_1d(i).ravel() for i in arrays[:n])
+
+
+def check_data(data):
+    """
+    Check the *data* argument and make sure it's a tuple.
+    If the data is a single array, return it as a tuple with a single element.
+
+    This is the default format accepted and used by all gridders and processing
+    functions.
+
+    Examples
+    --------
+
+    >>> check_data([1, 2, 3])
+    ([1, 2, 3],)
+    >>> check_data(([1, 2], [3, 4]))
+    ([1, 2], [3, 4])
+    """
+    if not isinstance(data, tuple):
+        data = (data,)
+    return data
 
 
 def variance_to_weights(variance, tol=1e-15, dtype="float64"):


### PR DESCRIPTION
Simplify the code by using the `n_1d_arrays` utility function.

Had to move `check_data` to `utils` to avoid a circular dependency
problem. Not a big deal since it really doesn't depend on anything in
`base`.


**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
