### PR TITLE
Add citation info and a changelog

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -6,13 +6,13 @@ that goes into building and maintaining this project.
 
 If you used Verde in your research, please consider citing us:
 
-    Uieda, L. (2018). Verde v1.0.0: Processing and gridding spatial data using Green's
+    Uieda, L., and Hoese, D. (2018). Verde v1.0.0: Processing and gridding spatial data using Green's
     functions. Zenodo. https://doi.org/10.5281/zenodo.1415281
 
 Here is a Bibtex entry to make things easier if you're using Latex::
 
     @misc{verde,
-      author       = {Leonardo Uieda},
+      author       = {Leonardo Uieda and David Hoese},
       title        = {Verde v1.0.0: Processing and gridding spatial data using Green's functions},
       year         = 2018,
       publisher    = {Zenodo},

--- a/CITATION.rst
+++ b/CITATION.rst
@@ -1,0 +1,21 @@
+Citing Verde
+============
+
+This is research software **made by scientists**. Citations help us justify the effort
+that goes into building and maintaining this project.
+
+If you used Verde in your research, please consider citing us:
+
+    Uieda, L. (2018). Verde v1.0.0: Processing and gridding spatial data using Green's
+    functions. Zenodo. https://doi.org/10.5281/zenodo.1415281
+
+Here is a Bibtex entry to make things easier if you're using Latex::
+
+    @misc{verde,
+      author       = {Leonardo Uieda},
+      title        = {Verde v1.0.0: Processing and gridding spatial data using Green's functions},
+      year         = 2018,
+      publisher    = {Zenodo},
+      doi          = {10.5281/zenodo.1415281},
+      url          = {https://doi.org/10.5281/zenodo.1415281}
+    }

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -83,6 +83,10 @@ There are a few steps that still must be done manually, though.
 3. Replace the PR number in the commit titles with a link to the Github PR page.
 4. Copy the remaining changes to `doc/changes.rst` under a new section for the
    intended release.
+5. Reserve a DOI in [Zenodo](https://zenodo.org/) and pre-fill the fields for archiving
+   the new release. Include as authors anyone who made contributions between now and the
+   last release.
+6. Include the DOI badge in the changelog.
 5. Add a link to the new release version documentation in `README.rst`.
 5. Open a new PR with the updated changelog.
 
@@ -102,6 +106,11 @@ This should trigger Travis to do all the work for us.
 A new source distribution will be uploaded to PyPI, a new folder with the documentation
 HTML will be pushed to *gh-pages*, and the `latest` link will be updated to point to
 this new folder.
+
+### Archiving on Zenodo
+
+Grab a zip file from the Github release and upload to Zenodo using the previously
+reserved DOI.
 
 ### Updating the conda package
 

--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,17 @@ Contacting us
   where you can ask questions and leave comments.
 
 
+Citing Verde
+------------
+
+This is research software **made by scientists**. Citations help us justify the effort
+that goes into building and maintaining this project. If you used Verde for your
+research, please consider citing us.
+
+See our `CITATION file <https://github.com/fatiando/verde/blob/master/CITATION.rst>`__
+to find out more.
+
+
 Contributing
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ This is research software **made by scientists**. Citations help us justify the 
 that goes into building and maintaining this project. If you used Verde for your
 research, please consider citing us.
 
-See our `CITATION file <https://github.com/fatiando/verde/blob/master/CITATION.rst>`__
+See our `CITATION.rst file <https://github.com/fatiando/verde/blob/master/CITATION.rst>`__
 to find out more.
 
 
@@ -162,4 +162,4 @@ Documentation for other versions
 * `Development <http://www.fatiando.org/verde/dev>`__ (reflects the *master* branch on
   Github)
 * `Latest release <http://www.fatiando.org/verde/latest>`__
-* `v0.1.0 <http://www.fatiando.org/verde/v0.1a0>`__
+* `v1.0.0 <http://www.fatiando.org/verde/v1.0.0>`__

--- a/README.rst
+++ b/README.rst
@@ -36,18 +36,6 @@ Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
  .. placeholder-for-doc-index
 
 
-Disclaimer
-----------
-
-🚨 **This package is in early stages of design and implementation.** 🚨
-
-We welcome any feedback and ideas!
-Let us know by submitting
-`issues on Github <https://github.com/fatiando/verde/issues>`__
-or send us a message on our
-`Gitter chatroom <https://gitter.im/fatiando/fatiando>`__.
-
-
 About
 -----
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -1,0 +1,14 @@
+.. _changes:
+
+Changelog
+=========
+
+Version 1.0.0 (2018-09-XX)
+--------------------------
+
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1415281.svg
+   :target: https://doi.org/10.5281/zenodo.1415281
+
+* First release of Verde. Establishes the gridder API and includes blocked reductions,
+  bi-harmonic splines [Sandwell1987]_, coupled 2D interpolation [SandwellWessel2016]_,
+  chaining operations to form a pipeline, and more.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -3,7 +3,7 @@
 Changelog
 =========
 
-Version 1.0.0 (2018-09-XX)
+Version 1.0.0 (2018-09-13)
 --------------------------
 
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1415281.svg

--- a/doc/citing.rst
+++ b/doc/citing.rst
@@ -1,0 +1,3 @@
+.. _citing:
+
+.. include:: ../CITATION.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,8 +20,8 @@
 
     tutorials/overview.rst
     install.rst
-    gallery/index.rst
     citing.rst
+    gallery/index.rst
 
 .. toctree::
     :maxdepth: 2
@@ -43,5 +43,5 @@
     :caption: Reference documentation
 
     api/index.rst
-    references.rst
     changes.rst
+    references.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,6 +21,7 @@
     tutorials/overview.rst
     install.rst
     gallery/index.rst
+    citing.rst
 
 .. toctree::
     :maxdepth: 2
@@ -35,5 +36,12 @@
     tutorials/model_selection.rst
     tutorials/weights.rst
     tutorials/vectors.rst
+
+.. toctree::
+    :maxdepth: 2
+    :hidden:
+    :caption: Reference documentation
+
     api/index.rst
     references.rst
+    changes.rst


### PR DESCRIPTION
In preparation for the 1.0.0 release, add a changelog with a minimal
entry, instructions for archiving on Zenodo, and citation information
(Zenodo for now until there is a paper).