### PR TITLE
Force matplotlib<3.0.0 because of Cartopy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
     # Development requirements
     - dask
     - pyproj
-    - matplotlib
+    - matplotlib<3.0.0
     - cartopy
     - jupyter
     - pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,8 @@
 # Black is not included because it requires Python 3.6
 dask
 pyproj
-matplotlib
+# 3.0.0 is causing Cartopy to break
+matplotlib<3.0.0
 cartopy
 jupyter
 pytest


### PR DESCRIPTION
Cartopy is breaking under matplotlib 3.0.0. Require <3.0.0 until they
sort it out.

Fixes the failing CIs in #136 
