### PR TITLE
Remove default shape for BaseGridder.grid

### DIFF
--- a/data/examples/checkerboard.py
+++ b/data/examples/checkerboard.py
@@ -23,7 +23,7 @@ print(
 )
 
 # Generating a grid results in a xarray.Dataset
-grid = synth.grid()
+grid = synth.grid(shape=(150, 100))
 print("\nData grid:\n", grid)
 
 # while a random scatter generates a pandas.DataFrame

--- a/verde/base.py
+++ b/verde/base.py
@@ -308,8 +308,6 @@ class BaseGridder(BaseEstimator):
         verde.grid_coordinates : Generate the coordinate values for the grid.
 
         """
-        if shape is None and spacing is None:
-            shape = (101, 101)
         dims = get_dims(self, dims)
         region = get_instance_region(self, region)
         coordinates = grid_coordinates(

--- a/verde/tests/test_scipy.py
+++ b/verde/tests/test_scipy.py
@@ -47,7 +47,7 @@ def test_scipy_gridder_region():
     region = (1000, 5000, -8000, -6000)
     synth = CheckerBoard(region=region)
     # Test using xarray objects
-    grid = synth.grid()
+    grid = synth.grid(shape=(101, 101))
     coords = grid_coordinates(region, grid.scalars.shape)
     grd = ScipyGridder().fit(coords, grid.scalars)
     npt.assert_allclose(grd.region_, region)


### PR DESCRIPTION
There is no reason to have one and it wasn't even implemented in
`grid_coordinates`. This only affected a single example of CheckerBoard
that didn't set `shape` or `spacing`.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
