### PR TITLE
Set default n_splits=5 in scikit-learn KFold

### DIFF
--- a/verde/model_selection.py
+++ b/verde/model_selection.py
@@ -159,7 +159,7 @@ def cross_val_score(estimator, coordinates, data, weights=None, cv=None, client=
     >>> # A linear trend should perfectly predict this data
     >>> scores = cross_val_score(Trend(degree=1), coords, data)
     >>> print(', '.join(['{:.2f}'.format(score) for score in scores]))
-    1.00, 1.00, 1.00
+    1.00, 1.00, 1.00, 1.00, 1.00
 
     >>> # To run parallel, we need to create a dask.distributed Client. It will
     >>> # create a local cluster if no arguments are given so we can run the
@@ -182,7 +182,7 @@ def cross_val_score(estimator, coordinates, data, weights=None, cv=None, client=
     if client is None:
         client = DummyClient()
     if cv is None:
-        cv = KFold(shuffle=True, random_state=0)
+        cv = KFold(shuffle=True, random_state=0, n_splits=5)
     ndata = data[0].size
     args = (coordinates, data, weights)
     scores = []


### PR DESCRIPTION
scikit-learn will change the default from 3 to 5 in an upcoming release.
Set the value to 5 now to prepare and make sure that future changes
don't affect us.

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
