### PR TITLE
Add extra_coords option to coordinate generators

### DIFF
--- a/verde/tests/test_blockreduce.py
+++ b/verde/tests/test_blockreduce.py
@@ -29,11 +29,11 @@ def test_block_reduce():
 def test_block_reduce_scatter():
     "Try reducing constant values in a dense enough scatter"
     region = (-5, 0, 5, 10)
-    east, north = scatter_points(region, size=10000, random_state=0)
-    data = 20 * np.ones_like(east)
+    coordinates = scatter_points(region, size=10000, random_state=0)
+    data = 20 * np.ones_like(coordinates[0])
     block_coords, block_data = BlockReduce(
         np.mean, 1, region=region, center_coordinates=True
-    ).filter((east, north), data)
+    ).filter(coordinates, data)
     assert len(block_coords[0]) == 25
     assert len(block_coords[1]) == 25
     assert len(block_data) == 25


### PR DESCRIPTION
The `grid_coordinates`, `scatter_points`, and `profile_coordinates` all
accept a new a `extra_coords` argument with the constant value to be
used as an extra coordinate. If given, then the output will have an
extra coordinate array of the same shape as the rest and with that
single value. If a list is given, multiple extra coordinate arrays will
be returned.

This can be used to specify constant coordinates to a grid generator,
like height or time, to generate a 2D grid/scatter/profile from data
that requires 3+ coordinates.

A step towards #138

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
