### PR TITLE
Don't use the Jacobian for prediction

### DIFF
--- a/verde/spline.py
+++ b/verde/spline.py
@@ -241,7 +241,7 @@ def predict_numba(east, north, force_east, force_north, mindist, forces, result)
 
 
 def predict_numpy(east, north, force_east, force_north, mindist, forces, result):
-    "Calculate the predicted data using numpy to speed things up."
+    "Calculate the predicted data using numpy."
     result[:] = 0
     for j in range(forces.size):
         distance = np.sqrt((east - force_east[j]) ** 2 + (north - force_north[j]) ** 2)

--- a/verde/spline.py
+++ b/verde/spline.py
@@ -78,7 +78,7 @@ class Spline(BaseGridder):
 
     Attributes
     ----------
-    forces_ : array
+    force_ : array
         The estimated forces that fit the observed data.
     region_ : tuple
         The boundaries (``[W, E, S, N]``) of the data used to fit the

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -116,3 +116,14 @@ def test_spline_jacobian_implementations():
     jac_numpy = Spline(engine="numpy").jacobian(coords, coords)
     jac_numba = Spline(engine="numba").jacobian(coords, coords)
     npt.assert_allclose(jac_numpy, jac_numba)
+
+
+@requires_numba
+def test_spline_predict_implementations():
+    "Compare the numba and numpy implementations."
+    size = 500
+    data = CheckerBoard().scatter(size=size, random_state=1)
+    coords = (data.easting, data.northing)
+    pred_numpy = Spline(engine="numpy").fit(coords, data.scalars).predict(coords)
+    pred_numba = Spline(engine="numba").fit(coords, data.scalars).predict(coords)
+    npt.assert_allclose(pred_numpy, pred_numba)

--- a/verde/tests/test_vector.py
+++ b/verde/tests/test_vector.py
@@ -18,7 +18,7 @@ from ..vector import VectorSpline2D, Vector
 def data2d():
     "Make 2 component vector data"
     synth = CheckerBoard()
-    coordinates = grid_coordinates(synth.region, shape=(30, 25))
+    coordinates = grid_coordinates(synth.region, shape=(15, 20))
     data = tuple(synth.predict(coordinates).ravel() for i in range(2))
     return tuple(i.ravel() for i in coordinates), data
 
@@ -38,7 +38,7 @@ def test_vector2d(data2d):
 def test_vector2d_weights(data2d):
     "Use unit weights and a regular grid solution"
     coords, data = data2d
-    outlier = 100
+    outlier = 10
     outlier_value = 100000
     data_outlier = tuple(i.copy() for i in data)
     data_outlier[0][outlier] += outlier_value
@@ -68,6 +68,15 @@ def test_vector2d_jacobian_implementations(data2d):
     jac_numpy = VectorSpline2D(engine="numpy").jacobian(coords, coords)
     jac_numba = VectorSpline2D(engine="numba").jacobian(coords, coords)
     npt.assert_allclose(jac_numpy, jac_numba)
+
+
+@requires_numba
+def test_vector2d_predict_implementations(data2d):
+    "Compare the numba and numpy implementations."
+    coords, data = data2d
+    pred_numpy = VectorSpline2D(engine="numpy").fit(coords, data).predict(coords)
+    pred_numba = VectorSpline2D(engine="numba").fit(coords, data).predict(coords)
+    npt.assert_allclose(pred_numpy, pred_numba, atol=1e-4)
 
 
 ########################################################################################

--- a/verde/vector.py
+++ b/verde/vector.py
@@ -285,10 +285,38 @@ class VectorSpline2D(BaseGridder):
 
         """
         check_is_fitted(self, ["force_"])
-        jac = self.jacobian(coordinates[:2], self.force_coords)
+        force_east, force_north = self.force_coords
+        east, north = n_1d_arrays(coordinates, n=2)
         cast = np.broadcast(*coordinates[:2])
         npoints = cast.size
-        components = jac.dot(self.force_).reshape((2, npoints))
+        components = (
+            np.empty(npoints, dtype=east.dtype),
+            np.empty(npoints, dtype=east.dtype),
+        )
+        if parse_engine(self.engine) == "numba":
+            components = predict_2d_numba(
+                east,
+                north,
+                force_east,
+                force_north,
+                self.mindist,
+                self.poisson,
+                self.force_,
+                components[0],
+                components[1],
+            )
+        else:
+            components = predict_2d_numpy(
+                east,
+                north,
+                force_east,
+                force_north,
+                self.mindist,
+                self.poisson,
+                self.force_,
+                components[0],
+                components[1],
+            )
         return tuple(comp.reshape(cast.shape) for comp in components)
 
     def jacobian(self, coordinates, force_coords, dtype="float64"):
@@ -326,59 +354,102 @@ class VectorSpline2D(BaseGridder):
         east, north = n_1d_arrays(coordinates, n=2)
         jac = np.empty((east.size * 2, force_east.size * 2), dtype=dtype)
         if parse_engine(self.engine) == "numba":
-            jac = jacobian_numba(
+            jac = jacobian_2d_numba(
                 east, north, force_east, force_north, self.mindist, self.poisson, jac
             )
         else:
-            jac = jacobian_numpy(
+            jac = jacobian_2d_numpy(
                 east, north, force_east, force_north, self.mindist, self.poisson, jac
             )
         return jac
 
 
-def jacobian_numpy(east, north, force_east, force_north, mindist, poisson, jac):
-    """
-    Calculate the Jacobian matrix using numpy broadcasting.
-    """
+def predict_2d_numpy(
+    east, north, force_east, force_north, mindist, poisson, forces, vec_east, vec_north
+):
+    "Calculate the predicted data using numpy."
+    vec_east[:] = 0
+    vec_north[:] = 0
+    nforces = forces.size // 2
+    for j in range(nforces):
+        green_ee, green_nn, green_ne = greens_functions_2d(
+            east - force_east[j], north - force_north[j], mindist, poisson
+        )
+        vec_east += green_ee * forces[j] + green_ne * forces[j + nforces]
+        vec_north += green_ne * forces[j] + green_nn * forces[j + nforces]
+    return vec_east, vec_north
+
+
+@jit(nopython=True, target="cpu", fastmath=True, parallel=True)
+def predict_2d_numba(
+    east, north, force_east, force_north, mindist, poisson, forces, vec_east, vec_north
+):
+    "Calculate the predicted data using numba to speed things up."
+    nforces = forces.size // 2
+    for i in numba.prange(east.size):  # pylint: disable=not-an-iterable
+        vec_east[i] = 0
+        vec_north[i] = 0
+        for j in range(nforces):
+            green_ee, green_nn, green_ne = greens_functions_2d_jit(
+                east[i] - force_east[j], north[i] - force_north[j], mindist, poisson
+            )
+            vec_east[i] += green_ee * forces[j] + green_ne * forces[j + nforces]
+            vec_north[i] += green_ne * forces[j] + green_nn * forces[j + nforces]
+    return vec_east, vec_north
+
+
+def jacobian_2d_numpy(east, north, force_east, force_north, mindist, poisson, jac):
+    "Calculate the Jacobian matrix using numpy broadcasting."
     npoints = east.size
     nforces = force_east.size
     # Reshaping the data coordinates to a column vector will automatically build a
-    # distance matrix between each data point and force.
-    east_orig = east.reshape((npoints, 1)) - force_east
-    north_orig = north.reshape((npoints, 1)) - force_north
-    distance = np.hypot(east_orig, north_orig)
+    # Green's functions matrix between each data point and force.
+    green_ee, green_nn, green_ne = greens_functions_2d(
+        east.reshape((npoints, 1)) - force_east,
+        north.reshape((npoints, 1)) - force_north,
+        mindist,
+        poisson,
+    )
+    jac[:npoints, :nforces] = green_ee
+    jac[npoints:, nforces:] = green_nn
+    jac[:npoints, nforces:] = green_ne
+    jac[npoints:, :nforces] = green_ne  # J is symmetric
+    return jac
+
+
+@jit(nopython=True, target="cpu", fastmath=True, parallel=True)
+def jacobian_2d_numba(east, north, force_east, force_north, mindist, poisson, jac):
+    "Calculate the Jacobian matrix using numba to speed things up."
+    nforces = force_east.size
+    npoints = east.size
+    for i in numba.prange(npoints):  # pylint: disable=not-an-iterable
+        for j in range(nforces):
+            green_ee, green_nn, green_ne = greens_functions_2d_jit(
+                east[i] - force_east[j], north[i] - force_north[j], mindist, poisson
+            )
+            jac[i, j] = green_ee
+            jac[i + npoints, j + nforces] = green_nn
+            jac[i, j + nforces] = green_ne
+            jac[i + npoints, j] = green_ne  # J is symmetric
+    return jac
+
+
+def greens_functions_2d(east, north, mindist, poisson):
+    "Calculate the Green's functions for the 2D elastic case."
+    distance = np.sqrt(east ** 2 + north ** 2)
     # The mindist factor helps avoid singular matrices when the force and
     # computation point are too close
     distance += mindist
     # Pre-compute common terms for the Green's functions of each component
     ln_r = (3 - poisson) * np.log(distance)
     over_r2 = (1 + poisson) / distance ** 2
-    jac[:npoints, :nforces] = ln_r + over_r2 * north_orig ** 2  # J_ee
-    jac[npoints:, nforces:] = ln_r + over_r2 * east_orig ** 2  # J_nn
-    jac[:npoints, nforces:] = -over_r2 * east_orig * north_orig  # J_ne
-    jac[npoints:, :nforces] = jac[:npoints, nforces:]  # J is symmetric
-    return jac
+    green_ee = ln_r + over_r2 * north ** 2
+    green_nn = ln_r + over_r2 * east ** 2
+    green_ne = -over_r2 * east * north
+    return green_ee, green_nn, green_ne
 
 
-@jit(nopython=True, target="cpu", fastmath=True)
-def jacobian_numba(east, north, force_east, force_north, mindist, poisson, jac):
-    """
-    Calculate the Jacobian matrix using numba to speed things up.
-    """
-    # pylint: disable=too-many-locals
-    nforces = force_east.size
-    npoints = east.size
-    for i in range(npoints):
-        for j in range(nforces):
-            east_orig = east[i] - force_east[j]
-            north_orig = north[i] - force_north[j]
-            distance = np.sqrt(east_orig ** 2 + north_orig ** 2)
-            distance += mindist
-            # Pre-compute common terms for the Green's functions of each component
-            ln_r = (3 - poisson) * np.log(distance)
-            over_r2 = (1 + poisson) / distance ** 2
-            jac[i, j] = ln_r + over_r2 * north_orig ** 2  # J_ee
-            jac[i + npoints, j + nforces] = ln_r + over_r2 * east_orig ** 2  # J_nn
-            jac[i, j + nforces] = -over_r2 * east_orig * north_orig  # J_ne
-            jac[i + npoints, j] = jac[i, j + nforces]  # J is symmetric
-    return jac
+# JIT compile the Greens functions for use in numba functions
+greens_functions_2d_jit = jit(  # pylint: disable=invalid-name
+    nopython=True, target="cpu", fastmath=True, parallel=True
+)(greens_functions_2d)

--- a/verde/vector.py
+++ b/verde/vector.py
@@ -185,14 +185,14 @@ class VectorSpline2D(BaseGridder):
         then will be set to the data coordinates the first time
         :meth:`~verde.VectorSpline2D.fit` is called.
     engine : str
-        Computation engine for the Jacobian matrix. Can be ``'auto'``, ``'numba'``, or
-        ``'numpy'``. If ``'auto'``, will use numba if it is installed or numpy
-        otherwise. The numba version is multi-threaded and considerably faster, which
+        Computation engine for the Jacobian matrix and predictions. Can be ``'auto'``,
+        ``'numba'``, or ``'numpy'``. If ``'auto'``, will use numba if it is installed or
+        numpy otherwise. The numba version is multi-threaded and usually faster, which
         makes fitting and predicting faster.
 
     Attributes
     ----------
-    forces_ : array
+    force_ : array
         The estimated forces that fit the observed data.
     region_ : tuple
         The boundaries (``[W, E, S, N]``) of the data used to fit the


### PR DESCRIPTION
All gridders create a Jacobian matrix to make predictions (using a dot product with the estimated parameters). This is very inefficient with regards to memory. Generating large*ish* grids requires a huge amount of RAM.

Replace these with a for loop summation. Accelerate them with numba to achieve the same performance. The pure Python version is slower than the dot product but at least it won't blow up memory.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [X] Add new public functions/methods/classes to `doc/api/index.rst`.
- [X] Write detailed docstrings for all functions/methods.
- [X] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
