### PR TITLE
Test and support Python 3.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,6 +14,8 @@ environment:
           PYTHON: 3.5
         - MINICONDA: C:\Miniconda36-x64
           PYTHON: 3.6
+        - MINICONDA: C:\Miniconda37-x64
+          PYTHON: 3.7
 
 init:
     # Add miniconda to the PATH

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,6 +36,8 @@ install:
     - cmd: continuous-integration\appveyor\setup-miniconda.bat
     # Activate the new environment
     - cmd: activate testing
+    # Need a newer pip or it will fail with an error
+    - cmd: python -m pip install --upgrade pip
     # Show installed pkg information for postmortem diagnostic
     - cmd: conda list
     # Make a source package for the project and install it

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,11 @@ matrix:
               - PYTHON=3.5
               - TEST=true
               - BUILD_DOCS=true
+        - os: linux
+          env:
+              - PYTHON=3.7
+              - TEST=true
+              - BUILD_DOCS=true
         # Check tests pass when using optional dependencies.
         - os: linux
           env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,17 +63,27 @@ matrix:
               - PYTHON=3.7
               - TEST=true
               - BUILD_DOCS=true
+        - os: osx
+          env:
+              - PYTHON=3.5
+              - TEST=true
+              - BUILD_DOCS=true
+        - os: osx
+          env:
+              - PYTHON=3.6
+              - TEST=true
+              - BUILD_DOCS=true
+        - os: osx
+          env:
+              - PYTHON=3.7
+              - TEST=true
+              - BUILD_DOCS=true
         # Check tests pass when using optional dependencies.
         - os: linux
           env:
               - PYTHON=3.6
               - TEST=true
               - CONDA_INSTALL_EXTRA="pykdtree numba"
-        - os: osx
-          env:
-              - PYTHON=3.6
-              - TEST=true
-              - BUILD_DOCS=true
 
 # Setup the build environment
 before_install:

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ CLASSIFIERS = [
     "Topic :: Software Development :: Libraries",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
     "License :: OSI Approved :: {}".format(LICENSE),
 ]
 PLATFORMS = "Any"

--- a/verde/utils.py
+++ b/verde/utils.py
@@ -27,7 +27,7 @@ def parse_engine(engine):
         raise ValueError("Invalid engine '{}'. Must be in {}.".format(engine, engines))
     if engine == "auto":
         try:
-            import numba  # pylint: disable=unused-variable
+            import numba  # pylint: disable=unused-variable,unused-import
 
             return "numba"
         except ImportError:


### PR DESCRIPTION
Add a Python 3.7 build on Travis and the 3.7 language marker to
`setup.py`.
