### PR TITLE
Use the xarray pcolormesh to plot grids

### DIFF
--- a/examples/scipygridder.py
+++ b/examples/scipygridder.py
@@ -73,8 +73,8 @@ plt.figure(figsize=(7, 6))
 ax = plt.axes(projection=ccrs.Mercator())
 ax.set_title("Gridded Bathymetry Using Scipy")
 # Plot the gridded bathymetry
-pc = ax.pcolormesh(
-    grid.longitude, grid.latitude, grid.bathymetry_m, transform=crs, vmax=0, zorder=-1
+pc = grid.bathymetry_m.plot.pcolormesh(
+    ax=ax, transform=crs, vmax=0, zorder=-1, add_colorbar=False
 )
 plt.colorbar(pc).set_label("meters")
 # Plot the locations of the decimated data

--- a/examples/spline.py
+++ b/examples/spline.py
@@ -71,12 +71,8 @@ plt.figure(figsize=(8, 6))
 ax = plt.axes(projection=ccrs.Mercator())
 ax.set_title("Air temperature gridded with biharmonic spline")
 ax.plot(*coordinates, ".k", markersize=1, transform=ccrs.PlateCarree())
-tmp = ax.pcolormesh(
-    grid.longitude,
-    grid.latitude,
-    grid.temperature,
-    cmap="plasma",
-    transform=ccrs.PlateCarree(),
+tmp = grid.temperature.plot.pcolormesh(
+    ax=ax, cmap="plasma", transform=ccrs.PlateCarree(), add_colorbar=False
 )
 plt.colorbar(tmp).set_label("Air temperature (C)")
 # Use an utility function to add tick labels and land and ocean features to the map.

--- a/examples/spline_weights.py
+++ b/examples/spline_weights.py
@@ -93,14 +93,14 @@ vd.datasets.setup_california_gps_map(ax, region=region)
 ax = axes[1]
 ax.set_title("Weighted spline interpolated velocity")
 maxabs = vd.maxabs(data.velocity_up) * 1000
-pc = ax.pcolormesh(
-    grid.longitude,
-    grid.latitude,
-    grid.velocity * 1000,
+pc = (grid.velocity * 1000).plot.pcolormesh(
+    ax=ax,
     cmap="seismic",
     vmin=-maxabs,
     vmax=maxabs,
     transform=crs,
+    add_colorbar=False,
+    add_labels=False,
 )
 cb = plt.colorbar(pc, ax=ax, orientation="horizontal", pad=0.05)
 cb.set_label("vertical velocity [mm/yr]")

--- a/examples/vector_trend.py
+++ b/examples/vector_trend.py
@@ -57,14 +57,14 @@ for ax, component, title in zip(axes, components, titles):
     ax.set_title(title)
     # Plot the trend in pseudo color
     maxabs = vd.maxabs(component)
-    tmp = ax.pcolormesh(
-        component.longitude,
-        component.latitude,
-        component.values,
+    tmp = component.plot.pcolormesh(
+        ax=ax,
         vmin=-maxabs,
         vmax=maxabs,
         cmap="seismic",
         transform=crs,
+        add_colorbar=False,
+        add_labels=False,
     )
     cb = plt.colorbar(tmp, ax=ax, orientation="horizontal", pad=0.05)
     cb.set_label("meters/year")

--- a/tutorials/chain.py
+++ b/tutorials/chain.py
@@ -118,13 +118,8 @@ print(grid)
 plt.figure(figsize=(7, 6))
 ax = plt.axes(projection=ccrs.Mercator())
 ax.set_title("Gridded result of the chain")
-pc = ax.pcolormesh(
-    grid.longitude,
-    grid.latitude,
-    grid.bathymetry,
-    transform=ccrs.PlateCarree(),
-    vmax=0,
-    zorder=-1,
+pc = grid.bathymetry.plot.pcolormesh(
+    ax=ax, transform=ccrs.PlateCarree(), vmax=0, zorder=-1, add_colorbar=False
 )
 plt.colorbar(pc).set_label("meters")
 vd.datasets.setup_baja_bathymetry_map(ax)
@@ -155,12 +150,8 @@ print(grid_trend)
 plt.figure(figsize=(7, 6))
 ax = plt.axes(projection=ccrs.Mercator())
 ax.set_title("Gridded trend")
-pc = ax.pcolormesh(
-    grid_trend.longitude,
-    grid_trend.latitude,
-    grid_trend.bathymetry,
-    transform=ccrs.PlateCarree(),
-    zorder=-1,
+pc = grid_trend.bathymetry.plot.pcolormesh(
+    ax=ax, transform=ccrs.PlateCarree(), zorder=-1, add_colorbar=False
 )
 plt.colorbar(pc).set_label("meters")
 vd.datasets.setup_baja_bathymetry_map(ax)

--- a/tutorials/model_selection.py
+++ b/tutorials/model_selection.py
@@ -99,12 +99,12 @@ grid = chain.grid(
 plt.figure(figsize=(8, 6))
 ax = plt.axes(projection=ccrs.Mercator())
 ax.set_title("Gridded temperature")
-pc = ax.pcolormesh(
-    grid.longitude,
-    grid.latitude,
-    grid.temperature,
+pc = grid.temperature.plot.pcolormesh(
+    ax=ax,
     cmap="plasma",
     transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    add_labels=False,
 )
 plt.colorbar(pc).set_label("C")
 ax.plot(data.longitude, data.latitude, ".k", markersize=1, transform=ccrs.PlateCarree())
@@ -196,14 +196,14 @@ plt.figure(figsize=(14, 8))
 for i, title, grd in zip(range(2), ["Defaults", "Tuned"], [grid, grid_best]):
     ax = plt.subplot(1, 2, i + 1, projection=ccrs.Mercator())
     ax.set_title(title)
-    pc = ax.pcolormesh(
-        grd.longitude,
-        grd.latitude,
-        grd.temperature,
+    pc = grd.temperature.plot.pcolormesh(
+        ax=ax,
         cmap="plasma",
         transform=ccrs.PlateCarree(),
         vmin=data.air_temperature_c.min(),
         vmax=data.air_temperature_c.max(),
+        add_colorbar=False,
+        add_labels=False,
     )
     plt.colorbar(pc, orientation="horizontal", aspect=50, pad=0.05).set_label("C")
     ax.plot(

--- a/tutorials/projections.py
+++ b/tutorials/projections.py
@@ -71,8 +71,8 @@ grid = vd.distance_mask(proj_coords, maxdist=30e3, grid=grid)
 
 plt.figure(figsize=(7, 6))
 plt.title("Gridded bathymetry in Cartesian coordinates")
-plt.pcolormesh(grid.easting, grid.northing, grid.bathymetry, cmap="viridis", vmax=0)
-plt.colorbar().set_label("bathymetry (m)")
+pc = grid.bathymetry.plot.pcolormesh(cmap="viridis", vmax=0, add_colorbar=False)
+plt.colorbar(pc).set_label("bathymetry (m)")
 plt.plot(filter_coords[0], filter_coords[1], ".k", markersize=0.5)
 plt.xlabel("Easting (m)")
 plt.ylabel("Northing (m)")
@@ -127,13 +127,8 @@ grid_geo = vd.distance_mask(
 plt.figure(figsize=(7, 6))
 ax = plt.axes(projection=ccrs.Mercator())
 ax.set_title("Geographic grid of bathymetry")
-pc = ax.pcolormesh(
-    grid_geo.longitude,
-    grid_geo.latitude,
-    grid_geo.bathymetry,
-    transform=ccrs.PlateCarree(),
-    vmax=0,
-    zorder=-1,
+pc = grid_geo.bathymetry.plot.pcolormesh(
+    ax=ax, transform=ccrs.PlateCarree(), vmax=0, zorder=-1, add_colorbar=False
 )
 plt.colorbar(pc).set_label("meters")
 vd.datasets.setup_baja_bathymetry_map(ax, land=None)

--- a/tutorials/vectors.py
+++ b/tutorials/vectors.py
@@ -177,14 +177,14 @@ components = [grid.east_component, grid.north_component]
 for ax, component, title in zip(axes, components, titles):
     ax.set_title(title)
     maxabs = vd.maxabs(component)
-    tmp = ax.pcolormesh(
-        component.longitude,
-        component.latitude,
-        component.values,
+    tmp = component.plot.pcolormesh(
+        ax=ax,
         vmin=-maxabs,
         vmax=maxabs,
         cmap="bwr",
         transform=crs,
+        add_colorbar=False,
+        add_labels=False,
     )
     cb = plt.colorbar(tmp, ax=ax, orientation="horizontal", pad=0.05)
     cb.set_label("meters/year")

--- a/tutorials/weights.py
+++ b/tutorials/weights.py
@@ -272,14 +272,14 @@ crs = ccrs.PlateCarree()
 ax = axes[0]
 ax.set_title("Spline interpolation with weights")
 maxabs = vd.maxabs(data.velocity_up)
-pc = ax.pcolormesh(
-    grid.longitude,
-    grid.latitude,
-    grid.velocity,
+pc = grid.velocity.plot.pcolormesh(
+    ax=ax,
     cmap="seismic",
     vmin=-maxabs,
     vmax=maxabs,
     transform=crs,
+    add_colorbar=False,
+    add_labels=False,
 )
 plt.colorbar(pc, ax=ax, orientation="horizontal", pad=0.05).set_label("m/yr")
 ax.plot(data.longitude, data.latitude, ".k", markersize=0.1, transform=crs)
@@ -287,14 +287,14 @@ ax.coastlines()
 vd.datasets.setup_california_gps_map(ax)
 ax = axes[1]
 ax.set_title("Spline interpolation without weights")
-pc = ax.pcolormesh(
-    grid_unweighted.longitude,
-    grid_unweighted.latitude,
-    grid_unweighted.velocity,
+pc = grid_unweighted.velocity.plot.pcolormesh(
+    ax=ax,
     cmap="seismic",
     vmin=-maxabs,
     vmax=maxabs,
     transform=crs,
+    add_colorbar=False,
+    add_labels=False,
 )
 plt.colorbar(pc, ax=ax, orientation="horizontal", pad=0.05).set_label("m/yr")
 ax.plot(data.longitude, data.latitude, ".k", markersize=0.1, transform=crs)


### PR DESCRIPTION
It automatically adjusts the coordinates to match the center of each
pixel. Using matplotlib's pcolormesh would result in pixels being off by
0.5*spacing unless we have pixel registered grids (which we don't).

Fixes #147

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
