### PR TITLE
Use cross_val_score in model selection tutorial

### DIFF
--- a/tutorials/model_selection.py
+++ b/tutorials/model_selection.py
@@ -70,14 +70,8 @@ plt.show()
 # :meth:`~verde.base.BaseGridder.fit` method of most gridders using Python's argument
 # expansion using the ``*`` symbol.
 
-chain = vd.Chain(
-    [
-        ("reduce", vd.BlockReduce(np.mean, spacing * 111e3)),
-        ("trend", vd.Trend(degree=1)),
-        ("spline", vd.Spline()),
-    ]
-)
-chain.fit(*train)
+spline = vd.Spline()
+spline.fit(*train)
 
 ########################################################################################
 # Let's plot the gridded result to see what it looks like. We'll mask out grid points
@@ -88,7 +82,7 @@ mask = vd.distance_mask(
     coordinates=vd.grid_coordinates(region, spacing=spacing),
     projection=projection,
 )
-grid = chain.grid(
+grid = spline.grid(
     region=region,
     spacing=spacing,
     projection=projection,
@@ -122,30 +116,60 @@ plt.show()
 # for a given comparison dataset (``test`` in our case). The R² score is at most 1,
 # meaning a perfect prediction, but has no lower bound.
 
-score = chain.score(*test)
+score = spline.score(*test)
 print("R² score:", score)
 
 ########################################################################################
 # That's a good score meaning that our gridder is able to accurately predict data that
 # wasn't used in the gridding algorithm.
 #
+# Once caveat for this score is that it is highly dependent on the particular split that
+# we made. Changing the random number generator seed in :func:`verde.train_test_split`
+# will result in a different score.
+
+# Use 1 as a seed instead of 0
+train_other, test_other = vd.train_test_split(
+    proj_coords, data.air_temperature_c, test_size=0.3, random_state=1
+)
+print("R² score with seed 1:", spline.fit(*train_other).score(*test_other))
+
+########################################################################################
+# A more robust way of scoring the gridders is to use function
+# :func:`verde.cross_val_score`, which (by default) uses a `k-fold cross-validation
+# <https://en.wikipedia.org/wiki/Cross-validation_(statistics)#k-fold_cross-validation>`__.
+# It will split the data *k* times and return the score on each *fold*. We can then take
+# a mean of these scores.
+
+scores = vd.cross_val_score(spline, proj_coords, data.air_temperature_c)
+print("k-fold scores:", scores)
+print("Mean score:", np.mean(scores))
+
+########################################################################################
+# That is not a very good score so clearly the default arguments for
+# :class:`~verde.Spline` aren't suitable for this dataset. We could try different
+# combinations manually until we get a good score. A better way is to do this
+# automatically.
+
+########################################################################################
 # Tuning
 # ------
 #
 # :class:`~verde.Spline` has many parameters that can be set to modify the final result.
 # Mainly the ``damping`` regularization parameter and the ``mindist`` "fudge factor"
 # which smooths the solution. Would changing the default values give us a better score?
-# What if we used a 2nd degree trend instead?
 #
-# We can answer these questions by changing the values in our ``chain`` and
-# re-evaluating the model score. Let's test the following combinations of parameters:
+# We can answer these questions by changing the values in our ``spline`` and
+# re-evaluating the model score repeatedly for different values of these parameters.
+# Let's test the following combinations:
 
-dampings = [None, 1e-8, 1e-6]
-mindists = [10e3, 100e3, 1000e3]
-degrees = [1, 2, 3, 4]
+dampings = [None, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1]
+mindists = [5e3, 10e3, 25e3, 50e3, 75e3, 100e3]
 
 # Use itertools to create a list with all combinations of parameters to test
-parameter_sets = list(itertools.product(dampings, mindists, degrees))
+parameter_sets = [
+    dict(damping=combo[0], mindist=combo[1])
+    for combo in itertools.product(dampings, mindists)
+]
 print("Number of combinations:", len(parameter_sets))
 print("Combinations:", parameter_sets)
 
@@ -153,10 +177,9 @@ print("Combinations:", parameter_sets)
 # Now we can loop over the combinations and collect the scores for each parameter set.
 
 scores = []
-for damping, mindist, degree in parameter_sets:
-    chain.named_steps["spline"].set_params(damping=damping, mindist=mindist)
-    chain.named_steps["trend"].set_params(degree=degree)
-    score = chain.fit(*train).score(*test)
+for params in parameter_sets:
+    spline.set_params(**params)
+    score = np.mean(vd.cross_val_score(spline, proj_coords, data.air_temperature_c))
     scores.append(score)
 print(scores)
 
@@ -165,26 +188,21 @@ print(scores)
 
 best = np.argmax(scores)
 print("Best score:", scores[best])
-print("Best damping, mindist, and degree:", parameter_sets[best])
+print("Best parameters:", parameter_sets[best])
 
 ########################################################################################
-# We managed to get a slightly better score using the above configuration. That's not a
-# huge improvement but we also haven't tried that many parameter combinations.
+# That is a big improvement over our previous score!
 #
-# We can now configure our chain with the best configuration and re-fit. We could also
-# have kept separate chains, each fit on a combination, to avoid having to fit again.
-# Since this is a small dataset, it doesn't matter too much.
+# We can now configure our spline with the best configuration and re-fit.
 
-damping, mindist, degree = parameter_sets[best]
-chain.named_steps["spline"].set_params(damping=damping, mindist=mindist)
-chain.named_steps["trend"].set_params(degree=degree)
-chain.fit(*train)
+spline.set_params(**parameter_sets[best])
+spline.fit(proj_coords, data.air_temperature_c)
 
 ########################################################################################
 # Finally, we can make a grid with the best configuration to see how it compares to our
 # previous result.
 
-grid_best = chain.grid(
+grid_best = spline.grid(
     region=region,
     spacing=spacing,
     projection=projection,


### PR DESCRIPTION
The previous version used the `train_test_split`, which was highly
sensitive to the random number seed. Update the tutorial to show this
effect and use `cross_val_score` instead for a better metric. Use only a
single `Spline` instead of the `Chain` because it's not needed for this
dataset.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
