### PR TITLE
Utility function to create kdtrees

### DIFF
--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -4,12 +4,8 @@ Functions for generating and manipulating coordinates.
 import numpy as np
 from sklearn.utils import check_random_state
 
-try:
-    from pykdtree.kdtree import KDTree
-except ImportError:
-    from scipy.spatial import cKDTree as KDTree  # pylint: disable=no-name-in-module
-
 from .base.utils import n_1d_arrays
+from .utils import kdtree
 
 
 def check_region(region):
@@ -703,6 +699,6 @@ def block_split(coordinates, spacing, adjust="spacing", region=None):
             region, spacing=spacing, adjust=adjust, pixel_register=True
         )
     )
-    tree = KDTree(np.transpose(block_coords))
+    tree = kdtree(block_coords)
     labels = tree.query(np.transpose(n_1d_arrays(coordinates, 2)))[1]
     return block_coords, labels

--- a/verde/mask.py
+++ b/verde/mask.py
@@ -4,11 +4,7 @@ Mask grid points based on different criteria.
 import numpy as np
 
 from .base import n_1d_arrays
-
-try:
-    from pykdtree.kdtree import KDTree
-except ImportError:
-    from scipy.spatial import cKDTree as KDTree  # pylint: disable=no-name-in-module
+from .utils import kdtree
 
 
 def distance_mask(
@@ -104,7 +100,7 @@ def distance_mask(
     if projection is not None:
         data_coordinates = projection(*n_1d_arrays(data_coordinates, 2))
         coordinates = projection(*n_1d_arrays(coordinates, 2))
-    tree = KDTree(np.transpose(n_1d_arrays(data_coordinates, 2)))
+    tree = kdtree(data_coordinates[:2])
     distance = tree.query(np.transpose(n_1d_arrays(coordinates, 2)))[0].reshape(shape)
     mask = distance <= maxdist
     if grid is not None:


### PR DESCRIPTION
We support using pykdtree as a replacement for most kdtree operations
but the feature set is the not identical to the scipy implementation.
We had no way of dealing with this before and had some repeated
`try...except` code for importing the modules.

A new `kdtree` function in `verde/utils.py` centralizes the imports,
allows using the scipy kdtree even if pykdtree is installed,  and
handles transposing the coordinate arrays before creating the tree.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
