### PR TITLE
Dask tests fail on AppVeyor if using processes

### DIFF
--- a/verde/model_selection.py
+++ b/verde/model_selection.py
@@ -163,9 +163,10 @@ def cross_val_score(estimator, coordinates, data, weights=None, cv=None, client=
 
     >>> # To run parallel, we need to create a dask.distributed Client. It will
     >>> # create a local cluster if no arguments are given so we can run the
-    >>> # scoring on a single machine.
+    >>> # scoring on a single machine. We'll use threads instead of processes for this
+    >>> # example but in most cases you'll want processes.
     >>> from dask.distributed import Client
-    >>> client = Client()
+    >>> client = Client(processes=False)
     >>> # The scoring will now only submit tasks to our local cluster
     >>> scores = cross_val_score(Trend(degree=1), coords, data, client=client)
     >>> # The scores are not the actual values but Futures


### PR DESCRIPTION
The scheduler looses some processes for some reason. Use threads in the
example to fix this.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
