### PR TITLE
Assign authorship to "The Verde Developers"

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,7 +1,8 @@
-# Project Contributors
+# Project Authors
 
 This project was started by [Leonardo Uieda](http://www.leouieda.com/). The following
-people have made contributions to the project (in alphabetical order by last name):
+people have made contributions to the project (in alphabetical order by last name) and
+are considered "The Verde Developers":
 
 * [David Hoese](https://github.com/djhoese)
 * [Jesse Pisel](https://github.com/jessepisel)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Leonardo Uieda
+Copyright (c) 2017-2019 The Verde Developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -9,7 +9,7 @@ are permitted provided that the following conditions are met:
 * Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
-* Neither the name of Leonardo Uieda nor the names of any contributors
+* Neither the name of the Verde Developers nor the names of any contributors
   may be used to endorse or promote products derived from this software
   without specific prior written permission.
 

--- a/README.rst
+++ b/README.rst
@@ -95,9 +95,10 @@ Contacting us
 Citing Verde
 ------------
 
-This is research software **made by scientists**. Citations help us justify the effort
-that goes into building and maintaining this project. If you used Verde for your
-research, please consider citing us.
+This is research software **made by scientists** (see
+`AUTHORS.md <https://github.com/fatiando/verde/blob/master/AUTHORS.md>`__). Citations
+help us justify the effort that goes into building and maintaining this project. If you
+used Verde for your research, please consider citing us.
 
 See our `CITATION.rst file <https://github.com/fatiando/verde/blob/master/CITATION.rst>`__
 to find out more.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -78,7 +78,7 @@ master_doc = 'index'
 # General information about the project
 year = datetime.date.today().year
 project = 'Verde'
-copyright = '2018-{}, Leonardo Uieda'.format(year)
+copyright = '2017-{}, The Verde Developers'.format(year)
 if len(full_version.split('+')) > 1 or full_version == 'unknown':
     version = 'dev'
 else:

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ import versioneer
 
 NAME = "verde"
 FULLNAME = "Verde"
-AUTHOR = "Leonardo Uieda"
+AUTHOR = "The Verde Developers"
 AUTHOR_EMAIL = "leouieda@gmail.com"
-MAINTAINER = AUTHOR
+MAINTAINER = "Leonardo Uieda"
 MAINTAINER_EMAIL = AUTHOR_EMAIL
 LICENSE = "BSD License"
 URL = "https://github.com/fatiando/verde"


### PR DESCRIPTION
Replaces my name with "The Verde Developers" in authorship claims and
copyright notices. Include a definition of what that term means in the
`AUTHORS.md` file and include a reference to it in the README and doc
page.
Left my name and email as maintainer on the `setup.py` because we don't
have a project email yet.

Hopefully this will make things a bit more transparent and equal.