### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,6 @@ matrix:
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
               - CONDA_INSTALL_EXTRA="codecov twine"
-        - name: "Linux - Python 3.5"
-          os: linux
-          env:
-              - PYTHON=3.5
         # Check tests pass when using optional dependencies.
         - name: "Linux - Python 3.7 (optional deps)"
           os: linux

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,7 +6,7 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python 3.5 or greater**.
+You'll need **Python 3.6 or greater**.
 
 We recommend using the
 `Anaconda Python distribution <https://www.anaconda.com/download>`__

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ CLASSIFIERS = [
     "Intended Audience :: Education",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "License :: OSI Approved :: {}".format(LICENSE),
@@ -42,7 +41,7 @@ PACKAGE_DATA = {
     "verde.tests": ["data/*", "baseline/*"],
 }
 INSTALL_REQUIRES = ["numpy", "scipy", "pandas", "xarray", "scikit-learn", "pooch"]
-PYTHON_REQUIRES = ">=3.5"
+PYTHON_REQUIRES = ">=3.6"
 
 if __name__ == "__main__":
     setup(


### PR DESCRIPTION
Remove the CI checks, update the install instructions, and bump the
required version in `setup.py`.

Fixes #175

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
