### PR TITLE
Add enhanced support for geographic coordinates

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -59,7 +59,6 @@ Coordinate Manipulation
     project_region
     inside
     block_split
-    latlon_continuity
 
 Utilities
 ---------

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -59,6 +59,7 @@ Coordinate Manipulation
     project_region
     inside
     block_split
+    latlon_continuity
 
 Utilities
 ---------

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -11,6 +11,7 @@ from .coordinates import (
     get_region,
     pad_region,
     project_region,
+    latlon_continuity,
 )
 from .mask import distance_mask
 from .utils import variance_to_weights, maxabs, grid_to_table

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -11,7 +11,6 @@ from .coordinates import (
     get_region,
     pad_region,
     project_region,
-    _latlon_continuity,
 )
 from .mask import distance_mask
 from .utils import variance_to_weights, maxabs, grid_to_table

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -11,7 +11,7 @@ from .coordinates import (
     get_region,
     pad_region,
     project_region,
-    latlon_continuity,
+    _latlon_continuity,
 )
 from .mask import distance_mask
 from .utils import variance_to_weights, maxabs, grid_to_table

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -11,7 +11,7 @@ from .coordinates import (
     get_region,
     pad_region,
     project_region,
-    latlon_continuity,
+    longitude_continuity,
 )
 from .mask import distance_mask
 from .utils import variance_to_weights, maxabs, grid_to_table

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -662,7 +662,7 @@ def inside(coordinates, region, latlon=False):
     """
     check_region(region, latlon=latlon)
     if latlon:
-        region, coordinates = latlon_continuity(region, coordinates=coordinates)
+        region, coordinates = longitude_continuity(region, coordinates=coordinates)
     w, e, s, n = region
     easting, northing = coordinates[:2]
     # Allocate temporary arrays to minimize memory allocation overhead
@@ -779,7 +779,7 @@ def block_split(coordinates, spacing=None, adjust="spacing", region=None, shape=
     return block_coords, labels
 
 
-def latlon_continuity(region, coordinates=None):
+def longitude_continuity(region, coordinates=None):
     """
     Modify geographic region boundaries to ensure continuity around the globe.
 
@@ -806,16 +806,16 @@ def latlon_continuity(region, coordinates=None):
     Examples
     --------
 
-    >>> from verde import latlon_continuity
+    >>> from verde import longitude_continuity
     >>> # Modify region with west > east
     >>> w, e, s, n = 350, 10, -10, 10
-    >>> print(latlon_continuity([w, e, s, n]))
+    >>> print(longitude_continuity([w, e, s, n]))
     [-10  10 -10  10]
     >>> # Modify region and extra coordinates
     >>> from verde import grid_coordinates
     >>> region = [-70, -60, -40, -30]
     >>> coordinates = grid_coordinates([270, 320, -50, -20], spacing=5)
-    >>> region, [longitude, latitude] = latlon_continuity(region, coordinates)
+    >>> region, [longitude, latitude] = longitude_continuity(region, coordinates)
     >>> print(region)
     [290 300 -40 -30]
     >>> print(longitude.min(), longitude.max())
@@ -823,7 +823,7 @@ def latlon_continuity(region, coordinates=None):
     >>> # Another example
     >>> region = [-20, 20, -20, 20]
     >>> coordinates = grid_coordinates([0, 350, -90, 90], spacing=10)
-    >>> region, [longitude, latitude] = latlon_continuity(region, coordinates)
+    >>> region, [longitude, latitude] = longitude_continuity(region, coordinates)
     >>> print(region)
     [-20  20 -20  20]
     >>> print(longitude.min(), longitude.max())

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -753,11 +753,11 @@ def _latlon_continuity(west, east, longitude_coords):
 def _check_geographic_coordinates(coordinates):
     "Check if geographic coordinates are within accepted degrees intervals"
     longitude, latitude = coordinates[:2]
-    if (longitude > 360).all() or (longitude < -180).all():
+    if (longitude > 360).any() or (longitude < -180).any():
         raise ValueError(
-            "Invalid longitude coordinates. They should be < 360 and > -180 degrees"
+            "Invalid longitude coordinates. They should be < 360 and > -180 degrees."
         )
-    if (latitude > 90).all() or (latitude < -90).all():
+    if (latitude > 90).any() or (latitude < -90).any():
         raise ValueError(
-            "Invalid latitude coordinates. They should be < 90 and > -9 degrees"
+            "Invalid latitude coordinates. They should be < 90 and > -90 degrees."
         )

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -770,7 +770,7 @@ def longitude_continuity(coordinates, region):
     """
     Modify coordinates and region boundaries to ensure longitude continuity.
 
-    Longitudinal boundaries of the region are moved to the `[0, 360)` or `[-180, 180)`
+    Longitudinal boundaries of the region are moved to the ``[0, 360)`` or ``[-180, 180)``
     degrees interval depending which one is better suited for that specific region.
 
     Parameters

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -786,28 +786,30 @@ def latlon_continuity(region, coordinates=None):
     # Check if region is defined all around the globe
     all_globe = np.allclose(abs(e - w), 360)
     # Move coordinates to [0, 360)
+    interval_360 = True
     w = w % 360
     e = e % 360
-    if coordinates:
-        longitude = coordinates[0]
-        longitude = longitude % 360
     # Move west=0 and east=360 if region longitudes goes all around the globe
     if all_globe:
         w, e = 0, 360
     # Check if the [-180, 180) interval is better suited
     if w > e:
+        interval_360 = False
         e = ((e + 180) % 360) - 180
         w = ((w + 180) % 360) - 180
-        if coordinates:
-            longitude = ((longitude + 180) % 360) - 180
     region = np.array(region)
     region[:2] = w, e
+    # Modify extra coordinates if passed
     if coordinates:
+        longitude = coordinates[0]
+        if interval_360:
+            longitude = longitude % 360
+        else:
+            longitude = ((longitude + 180) % 360) - 180
         coordinates = np.array(coordinates)
         coordinates[0] = longitude
         return region, coordinates
-    else:
-        return region
+    return region
 
 
 def _check_geographic_coordinates(coordinates):

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -768,7 +768,7 @@ def block_split(coordinates, spacing=None, adjust="spacing", region=None, shape=
 
 def longitude_continuity(coordinates, region):
     """
-    Modify geographic region boundaries to ensure continuity around the globe.
+    Modify coordinates and region boundaries to ensure longitude continuity.
 
     Longitudinal boundaries of the region are moved to the `[0, 360)` or `[-180, 180)`
     degrees interval depending which one is better suited for that specific region.

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -31,16 +31,7 @@ def check_region(region, latlon=False):
         raise ValueError("Invalid region '{}'. Only 4 values allowed.".format(region))
     w, e, s, n = region
     if latlon:
-        if w > 360 or w < -180 or e > 360 or e < -180:
-            raise ValueError(
-                "Invalid region '{}'. ".format(region)
-                + "Longitudes must be > -180 degrees and < 360 degrees."
-            )
-        if s > 90 or s < -90 or n > 90 or n < -90:
-            raise ValueError(
-                "Invalid region '{}'. ".format(region)
-                + "Latitudes must be > -90 degrees and < 90 degrees."
-            )
+        _check_geographic_coordinates([np.array([w, e]), np.array([s, n])])
         if abs(e - w) > 360:
             raise ValueError(
                 "Invalid region '{}' (W, E, S, N). ".format(region)
@@ -757,3 +748,16 @@ def _latlon_continuity(west, east, longitude_coords):
         west = ((west + 180) % 360) - 180
         longitude_coords = ((longitude_coords + 180) % 360) - 180
     return west, east, longitude_coords
+
+
+def _check_geographic_coordinates(coordinates):
+    "Check if geographic coordinates are within accepted degrees intervals"
+    longitude, latitude = coordinates[:2]
+    if (longitude > 360).all() or (longitude < -180).all():
+        raise ValueError(
+            "Invalid longitude coordinates. They should be < 360 and > -180 degrees"
+        )
+    if (latitude > 90).all() or (latitude < -90).all():
+        raise ValueError(
+            "Invalid latitude coordinates. They should be < 90 and > -9 degrees"
+        )

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -722,6 +722,8 @@ def _latlon_continuity(west, east, longitude_coords):
     """
     Modify longitudinal geographic coordinates to ensure continuity around the globe.
     """
+    # Check if region is defined all around the globe
+    all_globe = bool(east - west == 360)
     # Move coordinates to [0, 360]
     west = west % 360
     east = east % 360
@@ -731,4 +733,7 @@ def _latlon_continuity(west, east, longitude_coords):
         east = ((east + 180) % 360) - 180
         west = ((west + 180) % 360) - 180
         longitude_coords = ((longitude_coords + 180) % 360) - 180
+    # Move west=0 and east=360 if region longitudes goes all around the globe
+    if all_globe:
+        west, east = 0, 360
     return west, east, longitude_coords

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -632,7 +632,6 @@ def inside(coordinates, region, latlon=False):
     """
     check_region(region, latlon=latlon)
     if latlon:
-        _check_geographic_coordinates(coordinates)
         region, coordinates = latlon_continuity(region, coordinates=coordinates)
     w, e, s, n = region
     easting, northing = coordinates[:2]
@@ -781,8 +780,9 @@ def latlon_continuity(region, coordinates=None):
     >>> print(longitude.min(), longitude.max())
     -180.0 170.0
     """
-    # Get longitudinal boundaries
-    w, e, = region[:2]
+    # Get longitudinal boundaries and check region
+    w, e, s, n = region[:4]
+    check_region([w, e, s, n], latlon=True)
     # Check if region is defined all around the globe
     all_globe = np.allclose(abs(e - w), 360)
     # Move coordinates to [0, 360)
@@ -801,6 +801,7 @@ def latlon_continuity(region, coordinates=None):
     region[:2] = w, e
     # Modify extra coordinates if passed
     if coordinates:
+        _check_geographic_coordinates(coordinates)
         longitude = coordinates[0]
         if interval_360:
             longitude = longitude % 360

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -782,11 +782,11 @@ def longitude_continuity(coordinates, region):
 
     Returns
     -------
+    modified_coordinates : array
+        Modified set of extra geographic coordinates.
     modified_region : array
         List containing the modified boundary coordinates `w, `e`, `s`, `n` of the
         region.
-    modified_coordinates : array (optional)
-        Modified set of extra geographic coordinates.
 
     Examples
     --------

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -8,7 +8,7 @@ from .base.utils import n_1d_arrays
 from .utils import kdtree
 
 
-def check_region(region):
+def check_region(region, latlon=False):
     """
     Check that the given region dimensions are valid.
 
@@ -30,14 +30,30 @@ def check_region(region):
     if len(region) != 4:
         raise ValueError("Invalid region '{}'. Only 4 values allowed.".format(region))
     w, e, s, n = region
-    if w > e:
-        raise ValueError(
-            "Invalid region '{}' (W, E, S, N). Must have W =< E.".format(region)
-        )
-    if s > n:
-        raise ValueError(
-            "Invalid region '{}' (W, E, S, N). Must have S =< N.".format(region)
-        )
+    if latlon:
+        for lon in (w, e):
+            if lon > 360 or lon < -180:
+                raise ValueError(
+                    "Invalid longitude coordinate '{}'. ".format(lon)
+                    + "Longitudes must be > -180 degrees and < 360 degrees."
+                )
+        for lat in (s, n):
+            if lat > 90 or lat < -90:
+                raise ValueError(
+                    "Invalid latitude coordinate '{}'. ".format(lat)
+                    + "Latitudes must be > -90 degrees and < 90 degrees."
+                )
+    else:
+        if w > e:
+            raise ValueError(
+                "Invalid region '{}' (W, E, S, N).Must have W =< E.".format(region)
+                + "If working with geographic coordinates, don't forget to add the "
+                + "latlon=True argument."
+            )
+        if s > n:
+            raise ValueError(
+                "Invalid region '{}' (W, E, S, N). Must have S =< N.".format(region)
+            )
 
 
 def get_region(coordinates):
@@ -622,7 +638,7 @@ def inside(coordinates, region, latlon=False):
     if latlon:
         w, e, easting = _latlon_continuity(w, e, easting)
         region = [w, e, s, n]
-    check_region(region)
+    check_region(region, latlon=latlon)
     # Allocate temporary arrays to minimize memory allocation overhead
     out = np.empty_like(easting, dtype=np.bool)
     tmp = tuple(np.empty_like(easting, dtype=np.bool) for i in range(4))

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -47,10 +47,10 @@ def check_region(region, latlon=False):
                 + "If working with geographic coordinates, don't forget to add the "
                 + "latlon=True argument."
             )
-        if s > n:
-            raise ValueError(
-                "Invalid region '{}' (W, E, S, N). Must have S =< N.".format(region)
-            )
+    if s > n:
+        raise ValueError(
+            "Invalid region '{}' (W, E, S, N). Must have S =< N.".format(region)
+        )
 
 
 def get_region(coordinates):

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -8,7 +8,7 @@ from .base.utils import n_1d_arrays
 from .utils import kdtree
 
 
-def check_region(region, latlon=False):
+def check_region(region, geographic=False):
     """
     Check that the given region dimensions are valid.
 
@@ -20,7 +20,7 @@ def check_region(region, latlon=False):
     region : list = [W, E, S, N]
         The boundaries of a given region in Cartesian or geographic
         coordinates.
-    latlon : bool (optional)
+    geographic : bool (optional)
         If True the `region` will be assumed to be geographic coordinates in degrees.
 
     Raises
@@ -32,7 +32,7 @@ def check_region(region, latlon=False):
     if len(region) != 4:
         raise ValueError("Invalid region '{}'. Only 4 values allowed.".format(region))
     w, e, s, n = region
-    if latlon:
+    if geographic:
         _check_geographic_coordinates([np.array([w, e]), np.array([s, n])])
         if abs(e - w) > 360:
             raise ValueError(
@@ -45,7 +45,7 @@ def check_region(region, latlon=False):
             raise ValueError(
                 "Invalid region '{}' (W, E, S, N).Must have W =< E.".format(region)
                 + "If working with geographic coordinates, don't forget to add the "
-                + "latlon=True argument."
+                + "geographic=True argument."
             )
     if s > n:
         raise ValueError(
@@ -603,7 +603,7 @@ def profile_coordinates(point1, point2, size, extra_coords=None):
     return tuple(coordinates), distances
 
 
-def inside(coordinates, region, latlon=False):
+def inside(coordinates, region, geographic=False):
     """
     Determine which points fall inside a given region.
 
@@ -618,7 +618,7 @@ def inside(coordinates, region, latlon=False):
     region : list = [W, E, S, N]
         The boundaries of a given region in Cartesian or geographic
         coordinates.
-    latlon : bool (optional)
+    geographic : bool (optional)
         If True both `region` and `coordinates` will be assumed to be geographic
         coordinates in degrees.
 
@@ -653,15 +653,15 @@ def inside(coordinates, region, latlon=False):
     >>> # Geographic coordinates are also supported
     >>> east, north = grid_coordinates([0, 350, -20, 20], spacing=10)
     >>> region = [-10, 10, -10, 10]
-    >>> are_inside = inside([east, north], region, latlon=True)
+    >>> are_inside = inside([east, north], region, geographic=True)
     >>> print(east[are_inside])
     [  0.  10. 350.   0.  10. 350.   0.  10. 350.]
     >>> print(north[are_inside])
     [-10. -10. -10.   0.   0.   0.  10.  10.  10.]
 
     """
-    check_region(region, latlon=latlon)
-    if latlon:
+    check_region(region, geographic=geographic)
+    if geographic:
         region, coordinates = longitude_continuity(region, coordinates=coordinates)
     w, e, s, n = region
     easting, northing = coordinates[:2]
@@ -831,7 +831,7 @@ def longitude_continuity(region, coordinates=None):
     """
     # Get longitudinal boundaries and check region
     w, e, s, n = region[:4]
-    check_region([w, e, s, n], latlon=True)
+    check_region([w, e, s, n], geographic=True)
     # Check if region is defined all around the globe
     all_globe = np.allclose(abs(e - w), 360)
     # Move coordinates to [0, 360)

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -638,7 +638,7 @@ def inside(coordinates, region):
      [False False False]]
 
     Geographic coordinates are also supported using :func:`verde.longitude_continuity`:
-    
+
     >>> from verde import longitude_continuity
     >>> east, north = grid_coordinates([0, 350, -20, 20], spacing=10)
     >>> region = [-10, 10, -10, 10]

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -20,6 +20,8 @@ def check_region(region, latlon=False):
     region : list = [W, E, S, N]
         The boundaries of a given region in Cartesian or geographic
         coordinates.
+    latlon : bool (optional)
+        If True the `region` will be assumed to be geographic coordinates in degrees.
 
     Raises
     ------

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -636,7 +636,9 @@ def inside(coordinates, region):
     [[False  True  True]
      [False  True  True]
      [False False False]]
-    >>> # Geographic coordinates are also supported
+
+    Geographic coordinates are also supported using :func:`verde.longitude_continuity`:
+    
     >>> from verde import longitude_continuity
     >>> east, north = grid_coordinates([0, 350, -20, 20], spacing=10)
     >>> region = [-10, 10, -10, 10]

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -56,13 +56,10 @@ def latlon_continuity(region, easting):
         Array with the longitude coordinates in degrees.
     """
     w, e, s, n = region[:]
-    # Unwrap phases from region and easting coordinates
-    w, e = np.degrees(np.unwrap(np.radians([w, e])))
-    easting = np.degrees(np.unwrap(np.radians(easting)))
     # Move region and easting coordinates to [0, 360]
-    w %= 360
-    e %= 360
-    easting %= 360
+    w = w % 360
+    e = e % 360
+    easting = easting % 360
     # Check if region boundaries are around the zero meridian (e.g. [350, 0])
     if w > e:
         w = ((w + 180) % 360) - 180

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -34,7 +34,7 @@ def check_region(region):
         raise ValueError(
             "Invalid region '{}' (W, E, S, N). Must have W =< E. ".format(region)
             + "If working with geographic coordinates, don't forget to match geographic"
-            + " region with coordinates using `longitude_continuity` function."
+            + " region with coordinates using 'verde.longitude_continuity'."
         )
     if s > n:
         raise ValueError(

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -31,18 +31,22 @@ def check_region(region, latlon=False):
         raise ValueError("Invalid region '{}'. Only 4 values allowed.".format(region))
     w, e, s, n = region
     if latlon:
-        for lon in (w, e):
-            if lon > 360 or lon < -180:
-                raise ValueError(
-                    "Invalid longitude coordinate '{}'. ".format(lon)
-                    + "Longitudes must be > -180 degrees and < 360 degrees."
-                )
-        for lat in (s, n):
-            if lat > 90 or lat < -90:
-                raise ValueError(
-                    "Invalid latitude coordinate '{}'. ".format(lat)
-                    + "Latitudes must be > -90 degrees and < 90 degrees."
-                )
+        if w > 360 or w < -180 or e > 360 or e < -180:
+            raise ValueError(
+                "Invalid region '{}'. ".format(region)
+                + "Longitudes must be > -180 degrees and < 360 degrees."
+            )
+        if s > 90 or s < -90 or n > 90 or n < -90:
+            raise ValueError(
+                "Invalid region '{}'. ".format(region)
+                + "Latitudes must be > -90 degrees and < 90 degrees."
+            )
+        if abs(e - w) > 360:
+            raise ValueError(
+                "Invalid region '{}' (W, E, S, N). ".format(region)
+                + "East and West boundaries must not be separated by an angle greater"
+                + "than 360 degrees."
+            )
     else:
         if w > e:
             raise ValueError(

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -66,7 +66,7 @@ def latlon_continuity(region, easting):
     # Check if region boundaries are around the zero meridian (e.g. [350, 0])
     if w > e:
         w = ((w + 180) % 360) - 180
-        e = ((w + 180) % 360) - 180
+        e = ((e + 180) % 360) - 180
         easting = ((easting + 180) % 360) - 180
     region = [w, e, s, n]
     return region, easting

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -816,11 +816,11 @@ def latlon_continuity(region, coordinates=None):
 def _check_geographic_coordinates(coordinates):
     "Check if geographic coordinates are within accepted degrees intervals"
     longitude, latitude = coordinates[:2]
-    if (longitude > 360).any() or (longitude < -180).any():
+    if np.any(longitude > 360) or np.any(longitude < -180):
         raise ValueError(
             "Invalid longitude coordinates. They should be < 360 and > -180 degrees."
         )
-    if (latitude > 90).any() or (latitude < -90).any():
+    if np.any(latitude > 90) or np.any(latitude < -90):
         raise ValueError(
             "Invalid latitude coordinates. They should be < 90 and > -90 degrees."
         )

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -655,6 +655,14 @@ def inside(coordinates, region, latlon=False):
     [[False  True  True]
      [False  True  True]
      [False False False]]
+    >>> # Geographic coordinates are also supported
+    >>> east, north = grid_coordinates([0, 350, -20, 20], spacing=10)
+    >>> region = [-10, 10, -10, 10]
+    >>> are_inside = inside([east, north], region, latlon=True)
+    >>> print(east[are_inside])
+    [  0.  10. 350.   0.  10. 350.   0.  10. 350.]
+    >>> print(north[are_inside])
+    [-10. -10. -10.   0.   0.   0.  10.  10.  10.]
 
     """
     w, e, s, n = region

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -64,6 +64,14 @@ def latlon_continuity(longitude, extra_coords=None):
     extra_coords : array (optional)
         Additional longitudinal coordinates moved to the best suited degrees interval.
         It is returned only if `extra_coords` argument is passed.
+
+    Examples
+    --------
+
+    >>> longitude = np.array([0, 10, 340, 350])
+    >>> print(latlon_continuity(longitude))
+    [  0  10 -20 -10]
+
     """
     # Move coordinates to [0, 360]
     longitude = longitude % 360

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -44,7 +44,7 @@ def latlon_continuity(longitude, extra_coords=None):
     """
     Modify longitudinal geographic coordinates to ensure continuity around the globe.
 
-    The longitude coordinates of  will be modified either to the [0, 360] degrees
+    The longitude coordinates will be modified either to the [0, 360] degrees
     interval or to the [-180, 180] as convenient.
     If `extra_coordinates` are passed, they will be modified but not taken into account
     when deciding the best interval.

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -779,7 +779,7 @@ def longitude_continuity(coordinates, region):
         Set of geographic coordinates that will be moved to the same degrees
         interval as the one of the modified region.
     region : list or array
-        List or array containing the boundary coordinates `w, `e`, `s`, `n` of the
+        List or array containing the boundary coordinates `w`, `e`, `s`, `n` of the
         region in degrees.
 
     Returns

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -56,6 +56,14 @@ def latlon_continuity(longitude, extra_coords=None):
     extra_coords : array (optional)
         Additional longitudinal coordinates that will be modified but not taken into
         account to decide the best interval.
+
+    Returns
+    -------
+    longitude : array
+        Longitudinal coordinates moved to the best suited degrees interval.
+    extra_coords : array (optional)
+        Additional longitudinal coordinates moved to the best suited degrees interval.
+        It is returned only if `extra_coords` argument is passed.
     """
     # Move coordinates to [0, 360]
     longitude = longitude % 360

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -40,54 +40,6 @@ def check_region(region):
         )
 
 
-def latlon_continuity(longitude, extra_coords=None):
-    """
-    Modify longitudinal geographic coordinates to ensure continuity around the globe.
-
-    The longitude coordinates will be modified either to the [0, 360] degrees
-    interval or to the [-180, 180] as convenient.
-    If `extra_coordinates` are passed, they will be modified but not taken into account
-    when deciding the best interval.
-
-    Parameters
-    ----------
-    longitude : array
-        Longitudinal coordinates that will be put on the same degrees interval.
-    extra_coords : array (optional)
-        Additional longitudinal coordinates that will be modified but not taken into
-        account to decide the best interval.
-
-    Returns
-    -------
-    longitude : array
-        Longitudinal coordinates moved to the best suited degrees interval.
-    extra_coords : array (optional)
-        Additional longitudinal coordinates moved to the best suited degrees interval.
-        It is returned only if `extra_coords` argument is passed.
-
-    Examples
-    --------
-
-    >>> longitude = np.array([0, 10, 340, 350])
-    >>> print(latlon_continuity(longitude))
-    [  0  10 -20 -10]
-
-    """
-    # Move coordinates to [0, 360]
-    longitude = longitude % 360
-    # Check if the [-180, 180] interval is better suited
-    change_interval = longitude.max() - longitude.min() > 180
-    if change_interval:
-        longitude = ((longitude + 180) % 360) - 180
-    # Perform the same tasks in case of extra_coordinates are defined
-    if extra_coords is not None:
-        extra_coords = extra_coords % 360
-        if change_interval:
-            extra_coords = ((extra_coords + 180) % 360) - 180
-        return longitude, extra_coords
-    return longitude
-
-
 def get_region(coordinates):
     """
     Get the bounding region of the given coordinates.
@@ -668,7 +620,7 @@ def inside(coordinates, region, latlon=False):
     w, e, s, n = region
     easting, northing = coordinates[:2]
     if latlon:
-        [w, e], easting = latlon_continuity(np.array([w, e]), extra_coords=easting)
+        [w, e], easting = _latlon_continuity(np.array([w, e]), extra_coords=easting)
         region = [w, e, s, n]
     check_region(region)
     # Allocate temporary arrays to minimize memory allocation overhead
@@ -764,3 +716,43 @@ def block_split(coordinates, spacing, adjust="spacing", region=None):
     tree = kdtree(block_coords)
     labels = tree.query(np.transpose(n_1d_arrays(coordinates, 2)))[1]
     return block_coords, labels
+
+
+def _latlon_continuity(longitude, extra_coords=None):
+    """
+    Modify longitudinal geographic coordinates to ensure continuity around the globe.
+
+    The longitude coordinates will be modified either to the [0, 360] degrees
+    interval or to the [-180, 180] as convenient.
+    If `extra_coordinates` are passed, they will be modified but not taken into account
+    when deciding the best interval.
+
+    Parameters
+    ----------
+    longitude : array
+        Longitudinal coordinates that will be put on the same degrees interval.
+    extra_coords : array (optional)
+        Additional longitudinal coordinates that will be modified but not taken into
+        account to decide the best interval.
+
+    Returns
+    -------
+    longitude : array
+        Longitudinal coordinates moved to the best suited degrees interval.
+    extra_coords : array (optional)
+        Additional longitudinal coordinates moved to the best suited degrees interval.
+        It is returned only if `extra_coords` argument is passed.
+    """
+    # Move coordinates to [0, 360]
+    longitude = longitude % 360
+    # Check if the [-180, 180] interval is better suited
+    change_interval = longitude.max() - longitude.min() > 180
+    if change_interval:
+        longitude = ((longitude + 180) % 360) - 180
+    # Perform the same tasks in case of extra_coordinates are defined
+    if extra_coords is not None:
+        extra_coords = extra_coords % 360
+        if change_interval:
+            extra_coords = ((extra_coords + 180) % 360) - 180
+        return longitude, extra_coords
+    return longitude

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -723,17 +723,17 @@ def _latlon_continuity(west, east, longitude_coords):
     Modify longitudinal geographic coordinates to ensure continuity around the globe.
     """
     # Check if region is defined all around the globe
-    all_globe = bool(east - west == 360)
+    all_globe = bool((east - west) % 360 == 0 and east != west)
     # Move coordinates to [0, 360]
     west = west % 360
     east = east % 360
     longitude_coords = longitude_coords % 360
+    # Move west=0 and east=360 if region longitudes goes all around the globe
+    if all_globe:
+        west, east = 0, 360
     # Check if the [-180, 180] interval is better suited
     if west > east:
         east = ((east + 180) % 360) - 180
         west = ((west + 180) % 360) - 180
         longitude_coords = ((longitude_coords + 180) % 360) - 180
-    # Move west=0 and east=360 if region longitudes goes all around the globe
-    if all_globe:
-        west, east = 0, 360
     return west, east, longitude_coords

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -123,79 +123,55 @@ def test_latlon_continuity():
     w, e = 10.5, 20.3
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region = (w, e, s, n)
-        coordinates_new, region_new = _latlon_continuity(coordinates, region)
-        longitude_new, latitude_new = coordinates_new[:]
-        w_new, e_new, s_new, n_new = region_new[:]
-        assert s_new == s
-        assert n_new == n
+        coordinates_new, region_new = _latlon_continuity(coordinates, (w, e, s, n))
+        w_new, e_new = region_new[:2]
         assert w_new == w
         assert e_new == e
-        npt.assert_allclose(longitude_new, longitude_360)
+        npt.assert_allclose(coordinates_new[0], longitude_360)
     # Check w, e in [-180, 180)
     w, e = -20, 20
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region = (w, e, s, n)
-        coordinates_new, region_new = _latlon_continuity(coordinates, region)
-        longitude_new, latitude_new = coordinates_new[:]
-        w_new, e_new, s_new, n_new = region_new[:]
-        assert s_new == s
-        assert n_new == n
+        coordinates_new, region_new = _latlon_continuity(coordinates, (w, e, s, n))
+        w_new, e_new = region_new[:2]
         assert w_new == -20
         assert e_new == 20
-        npt.assert_allclose(longitude_new, longitude_180)
+        npt.assert_allclose(coordinates_new[0], longitude_180)
     # Check region around the globe
     for w, e in [[0, 360], [-180, 180], [-20, 340]]:
         for longitude in [longitude_360, longitude_180]:
             coordinates = [longitude, latitude]
-            region = (w, e, s, n)
-            coordinates_new, region_new = _latlon_continuity(coordinates, region)
-            longitude_new, latitude_new = coordinates_new[:]
-            w_new, e_new, s_new, n_new = region_new[:]
-            assert s_new == s
-            assert n_new == n
+            coordinates_new, region_new = _latlon_continuity(coordinates, (w, e, s, n))
+            w_new, e_new = region_new[:2]
             assert w_new == 0
             assert e_new == 360
-            npt.assert_allclose(longitude_new, longitude_360)
+            npt.assert_allclose(coordinates_new[0], longitude_360)
     # Check w == e
     w, e = 20, 20
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region = (w, e, s, n)
-        coordinates_new, region_new = _latlon_continuity(coordinates, region)
-        longitude_new, latitude_new = coordinates_new[:]
-        w_new, e_new, s_new, n_new = region_new[:]
-        assert s_new == s
-        assert n_new == n
+        coordinates_new, region_new = _latlon_continuity(coordinates, (w, e, s, n))
+        w_new, e_new = region_new[:2]
         assert w_new == 20
         assert e_new == 20
-        npt.assert_allclose(longitude_new, longitude_360)
+        npt.assert_allclose(coordinates_new[0], longitude_360)
     # Check angle greater than 180
     w, e = 0, 200
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region = (w, e, s, n)
-        coordinates_new, region_new = _latlon_continuity(coordinates, region)
-        longitude_new, latitude_new = coordinates_new[:]
-        w_new, e_new, s_new, n_new = region_new[:]
-        assert s_new == s
-        assert n_new == n
+        coordinates_new, region_new = _latlon_continuity(coordinates, (w, e, s, n))
+        w_new, e_new = region_new[:2]
         assert w_new == 0
         assert e_new == 200
-        npt.assert_allclose(longitude_new, longitude_360)
+        npt.assert_allclose(coordinates_new[0], longitude_360)
     w, e = -160, 160
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region = (w, e, s, n)
-        coordinates_new, region_new = _latlon_continuity(coordinates, region)
-        longitude_new, latitude_new = coordinates_new[:]
-        w_new, e_new, s_new, n_new = region_new[:]
-        assert s_new == s
-        assert n_new == n
+        coordinates_new, region_new = _latlon_continuity(coordinates, (w, e, s, n))
+        w_new, e_new = region_new[:2]
         assert w_new == -160
         assert e_new == 160
-        npt.assert_allclose(longitude_new, longitude_180)
+        npt.assert_allclose(coordinates_new[0], longitude_180)
 
 
 def test_inside_latlon_0_360():

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -237,3 +237,50 @@ def test_inside_latlon_180_180():
     assert latitude_cut.size == 9
     assert set(longitude_cut) == set([20, 30, 40])
     assert set(latitude_cut) == set([-10, 0, 10])
+
+
+def test_inside_latlon_around_poles():
+    "Test inside function when region is around the poles"
+    longitude, latitude = grid_coordinates([0, 350, -90, 90], spacing=10.0)
+    # North Pole all around the globe
+    regions = [[0, 360, 70, 90], [-180, 180, 70, 90]]
+    for region in regions:
+        are_inside = inside([longitude, latitude], region, latlon=True)
+        assert longitude[are_inside].size == 3 * 36
+        assert latitude[are_inside].size == 3 * 36
+        assert set(longitude[are_inside]) == set(np.unique(longitude))
+        assert set(latitude[are_inside]) == set([70, 80, 90])
+    # South Pole all around the globe
+    regions = [[0, 360, -90, -70], [-180, 180, -90, -70]]
+    for region in regions:
+        are_inside = inside([longitude, latitude], region, latlon=True)
+        assert longitude[are_inside].size == 3 * 36
+        assert latitude[are_inside].size == 3 * 36
+        assert set(longitude[are_inside]) == set(np.unique(longitude))
+        assert set(latitude[are_inside]) == set([-90, -80, -70])
+    # Section at the North Pole
+    region = [40, 90, 70, 90]
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    assert longitude[are_inside].size == 3 * 6
+    assert latitude[are_inside].size == 3 * 6
+    assert set(longitude[are_inside]) == set([40, 50, 60, 70, 80, 90])
+    assert set(latitude[are_inside]) == set([70, 80, 90])
+    region = [-90, -40, 70, 90]
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    assert longitude[are_inside].size == 3 * 6
+    assert latitude[are_inside].size == 3 * 6
+    assert set(longitude[are_inside]) == set([270, 280, 290, 300, 310, 320])
+    assert set(latitude[are_inside]) == set([70, 80, 90])
+    # Section at the South Pole
+    region = [40, 90, -90, -70]
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    assert longitude[are_inside].size == 3 * 6
+    assert latitude[are_inside].size == 3 * 6
+    assert set(longitude[are_inside]) == set([40, 50, 60, 70, 80, 90])
+    assert set(latitude[are_inside]) == set([-90, -80, -70])
+    region = [-90, -40, -90, -70]
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    assert longitude[are_inside].size == 3 * 6
+    assert latitude[are_inside].size == 3 * 6
+    assert set(longitude[are_inside]) == set([270, 280, 290, 300, 310, 320])
+    assert set(latitude[are_inside]) == set([-90, -80, -70])

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -177,3 +177,26 @@ def test_invalid_geographic_region():
     w, e, s, n = -180, 200, -10, 10
     with pytest.raises(ValueError):
         longitude_continuity(None, [w, e, s, n])
+
+
+def test_invalid_geographic_coordinates():
+    "Check if passing invalid coordinates to longitude_continuity raises a ValueError"
+    boundaries = [0, 360, -90, 90]
+    spacing = 10
+    region = [-20, 20, -20, 20]
+    # Region with longitude point over boundaries
+    longitude, latitude = grid_coordinates(boundaries, spacing=spacing)
+    longitude[0] = -200
+    with pytest.raises(ValueError):
+        longitude_continuity([longitude, latitude], region)
+    longitude[0] = 400
+    with pytest.raises(ValueError):
+        longitude_continuity([longitude, latitude], region)
+    # Region with latitude point over boundaries
+    longitude, latitude = grid_coordinates(boundaries, spacing=spacing)
+    latitude[0] = -100
+    with pytest.raises(ValueError):
+        longitude_continuity([longitude, latitude], region)
+    latitude[0] = 100
+    with pytest.raises(ValueError):
+        longitude_continuity([longitude, latitude], region)

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -10,7 +10,6 @@ from ..coordinates import (
     spacing_to_shape,
     profile_coordinates,
     grid_coordinates,
-    inside,
     longitude_continuity,
 )
 

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -87,6 +87,21 @@ def test_check_region():
         check_region([-1, -2, -4, -3])
     with pytest.raises(ValueError):
         check_region([-2, -1, -2, -3])
+    check_region([0, 360, -90, 90], latlon=True)
+    with pytest.raises(ValueError):
+        check_region([-200, 0, -10, 10], latlon=True)
+    with pytest.raises(ValueError):
+        check_region([0, 400, -10, 10], latlon=True)
+    with pytest.raises(ValueError):
+        check_region([-200, -190, -10, 10], latlon=True)
+    with pytest.raises(ValueError):
+        check_region([-45, 45, -100, 0], latlon=True)
+    with pytest.raises(ValueError):
+        check_region([-45, 45, -100, 0], latlon=True)
+    with pytest.raises(ValueError):
+        check_region([-45, 45, 0, 100], latlon=True)
+    with pytest.raises(ValueError):
+        check_region([0, 360.5, -30, 30], latlon=True)
 
 
 def test_profile_coordiantes_fails():

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -11,7 +11,7 @@ from ..coordinates import (
     profile_coordinates,
     grid_coordinates,
     inside,
-    latlon_continuity,
+    longitude_continuity,
 )
 
 
@@ -112,7 +112,7 @@ def test_profile_coordiantes_fails():
         profile_coordinates((0, 1), (1, 2), size=-10)
 
 
-def test_latlon_continuity():
+def test_longitude_continuity():
     "Test continuous boundary conditions in geographic coordinates."
     # Define longitude coordinates around the globe for [0, 360) and [-180, 180)
     longitude_360 = np.linspace(0, 350, 36)
@@ -123,7 +123,7 @@ def test_latlon_continuity():
     w, e = 10.5, 20.3
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region_new, coordinates_new = latlon_continuity(
+        region_new, coordinates_new = longitude_continuity(
             (w, e, s, n), coordinates=coordinates
         )
         w_new, e_new = region_new[:2]
@@ -134,7 +134,7 @@ def test_latlon_continuity():
     w, e = -20, 20
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region_new, coordinates_new = latlon_continuity(
+        region_new, coordinates_new = longitude_continuity(
             (w, e, s, n), coordinates=coordinates
         )
         w_new, e_new = region_new[:2]
@@ -145,7 +145,7 @@ def test_latlon_continuity():
     for w, e in [[0, 360], [-180, 180], [-20, 340]]:
         for longitude in [longitude_360, longitude_180]:
             coordinates = [longitude, latitude]
-            region_new, coordinates_new = latlon_continuity(
+            region_new, coordinates_new = longitude_continuity(
                 (w, e, s, n), coordinates=coordinates
             )
             w_new, e_new = region_new[:2]
@@ -156,7 +156,7 @@ def test_latlon_continuity():
     w, e = 20, 20
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region_new, coordinates_new = latlon_continuity(
+        region_new, coordinates_new = longitude_continuity(
             (w, e, s, n), coordinates=coordinates
         )
         w_new, e_new = region_new[:2]
@@ -167,7 +167,7 @@ def test_latlon_continuity():
     w, e = 0, 200
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region_new, coordinates_new = latlon_continuity(
+        region_new, coordinates_new = longitude_continuity(
             (w, e, s, n), coordinates=coordinates
         )
         w_new, e_new = region_new[:2]
@@ -177,7 +177,7 @@ def test_latlon_continuity():
     w, e = -160, 160
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region_new, coordinates_new = latlon_continuity(
+        region_new, coordinates_new = longitude_continuity(
             (w, e, s, n), coordinates=coordinates
         )
         w_new, e_new = region_new[:2]

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -117,57 +117,82 @@ def test_latlon_continuity():
     # Define longitude coordinates around the globe for [0, 360) and [-180, 180)
     longitude_360 = np.linspace(0, 350, 36)
     longitude_180 = np.hstack((longitude_360[:18], longitude_360[18:] - 360))
+    latitude = np.linspace(-90, 90, 36)
+    s, n = -90, 90
     # Check w, e in [0, 360)
-    w, e = 10, 20
+    w, e = 10.5, 20.3
     for longitude in [longitude_360, longitude_180]:
-        w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
-        assert w_new == 10
-        assert e_new == 20
+        coordinates = [longitude, latitude]
+        region = (w, e, s, n)
+        coordinates_new, region_new = _latlon_continuity(coordinates, region)
+        longitude_new, latitude_new = coordinates_new[:]
+        w_new, e_new, s_new, n_new = region_new[:]
+        assert s_new == s
+        assert n_new == n
+        assert w_new == w
+        assert e_new == e
         npt.assert_allclose(longitude_new, longitude_360)
     # Check w, e in [-180, 180)
     w, e = -20, 20
     for longitude in [longitude_360, longitude_180]:
-        w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
+        coordinates = [longitude, latitude]
+        region = (w, e, s, n)
+        coordinates_new, region_new = _latlon_continuity(coordinates, region)
+        longitude_new, latitude_new = coordinates_new[:]
+        w_new, e_new, s_new, n_new = region_new[:]
+        assert s_new == s
+        assert n_new == n
         assert w_new == -20
         assert e_new == 20
         npt.assert_allclose(longitude_new, longitude_180)
     # Check region around the globe
-    for w, e in [[0, 360], [-180, 180], [20, 380], [0, 360 * 2]]:
+    for w, e in [[0, 360], [-180, 180], [-20, 340]]:
         for longitude in [longitude_360, longitude_180]:
-            w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
+            coordinates = [longitude, latitude]
+            region = (w, e, s, n)
+            coordinates_new, region_new = _latlon_continuity(coordinates, region)
+            longitude_new, latitude_new = coordinates_new[:]
+            w_new, e_new, s_new, n_new = region_new[:]
+            assert s_new == s
+            assert n_new == n
             assert w_new == 0
             assert e_new == 360
             npt.assert_allclose(longitude_new, longitude_360)
     # Check w == e
     w, e = 20, 20
     for longitude in [longitude_360, longitude_180]:
-        w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
+        coordinates = [longitude, latitude]
+        region = (w, e, s, n)
+        coordinates_new, region_new = _latlon_continuity(coordinates, region)
+        longitude_new, latitude_new = coordinates_new[:]
+        w_new, e_new, s_new, n_new = region_new[:]
+        assert s_new == s
+        assert n_new == n
         assert w_new == 20
         assert e_new == 20
         npt.assert_allclose(longitude_new, longitude_360)
     # Check angle greater than 180
     w, e = 0, 200
     for longitude in [longitude_360, longitude_180]:
-        w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
+        coordinates = [longitude, latitude]
+        region = (w, e, s, n)
+        coordinates_new, region_new = _latlon_continuity(coordinates, region)
+        longitude_new, latitude_new = coordinates_new[:]
+        w_new, e_new, s_new, n_new = region_new[:]
+        assert s_new == s
+        assert n_new == n
         assert w_new == 0
         assert e_new == 200
         npt.assert_allclose(longitude_new, longitude_360)
     w, e = -160, 160
     for longitude in [longitude_360, longitude_180]:
-        w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
-        assert w_new == -160
-        assert e_new == 160
-        npt.assert_allclose(longitude_new, longitude_180)
-    # Check overlapping regions
-    w, e = -200, 200
-    for longitude in [longitude_360, longitude_180]:
-        w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
-        assert w_new == 160
-        assert e_new == 200
-        npt.assert_allclose(longitude_new, longitude_360)
-    w, e = 200, -200
-    for longitude in [longitude_360, longitude_180]:
-        w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
+        coordinates = [longitude, latitude]
+        region = (w, e, s, n)
+        coordinates_new, region_new = _latlon_continuity(coordinates, region)
+        longitude_new, latitude_new = coordinates_new[:]
+        w_new, e_new, s_new, n_new = region_new[:]
+        assert s_new == s
+        assert n_new == n
         assert w_new == -160
         assert e_new == 160
         npt.assert_allclose(longitude_new, longitude_180)
@@ -202,14 +227,6 @@ def test_inside_latlon_0_360():
     assert longitude_cut.size == 9
     assert latitude_cut.size == 9
     assert set(longitude_cut) == set([0, 10, 350])
-    assert set(latitude_cut) == set([-10, 0, 10])
-    # Check region longitudes greater than 360
-    region = 380, 400, -10, 10
-    are_inside = inside([longitude, latitude], region, latlon=True)
-    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
-    assert longitude_cut.size == 9
-    assert latitude_cut.size == 9
-    assert set(longitude_cut) == set([20, 30, 40])
     assert set(latitude_cut) == set([-10, 0, 10])
 
 
@@ -250,14 +267,6 @@ def test_inside_latlon_180_180():
     assert longitude_cut.size == 9
     assert latitude_cut.size == 9
     assert set(longitude_cut) == set([-10, 0, 10])
-    assert set(latitude_cut) == set([-10, 0, 10])
-    # Check region longitudes greater than 360
-    region = 380, 400, -10, 10
-    are_inside = inside([longitude, latitude], region, latlon=True)
-    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
-    assert longitude_cut.size == 9
-    assert latitude_cut.size == 9
-    assert set(longitude_cut) == set([20, 30, 40])
     assert set(latitude_cut) == set([-10, 0, 10])
 
 

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -87,21 +87,21 @@ def test_check_region():
         check_region([-1, -2, -4, -3])
     with pytest.raises(ValueError):
         check_region([-2, -1, -2, -3])
-    check_region([0, 360, -90, 90], latlon=True)
+    check_region([0, 360, -90, 90], geographic=True)
     with pytest.raises(ValueError):
-        check_region([-200, 0, -10, 10], latlon=True)
+        check_region([-200, 0, -10, 10], geographic=True)
     with pytest.raises(ValueError):
-        check_region([0, 400, -10, 10], latlon=True)
+        check_region([0, 400, -10, 10], geographic=True)
     with pytest.raises(ValueError):
-        check_region([-200, -190, -10, 10], latlon=True)
+        check_region([-200, -190, -10, 10], geographic=True)
     with pytest.raises(ValueError):
-        check_region([-45, 45, -100, 0], latlon=True)
+        check_region([-45, 45, -100, 0], geographic=True)
     with pytest.raises(ValueError):
-        check_region([-45, 45, -100, 0], latlon=True)
+        check_region([-45, 45, -100, 0], geographic=True)
     with pytest.raises(ValueError):
-        check_region([-45, 45, 0, 100], latlon=True)
+        check_region([-45, 45, 0, 100], geographic=True)
     with pytest.raises(ValueError):
-        check_region([-100, 260.5, -30, 30], latlon=True)
+        check_region([-100, 260.5, -30, 30], geographic=True)
 
 
 def test_profile_coordiantes_fails():
@@ -186,7 +186,7 @@ def test_longitude_continuity():
         npt.assert_allclose(coordinates_new[0], longitude_180)
 
 
-def test_inside_latlon_0_360():
+def test_inside_geographic_0_360():
     "Check if inside gets points properly with geographic coordinates on [0, 360]"
     # Define longitude coordinates on 0, 360
     longitude = np.linspace(0, 350, 36)
@@ -194,7 +194,7 @@ def test_inside_latlon_0_360():
     longitude, latitude = np.meshgrid(longitude, latitude)
     # Check region longitudes in 0, 360
     region = 20, 40, -10, 10
-    are_inside = inside([longitude, latitude], region, latlon=True)
+    are_inside = inside([longitude, latitude], region, geographic=True)
     longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
     assert longitude_cut.size == 9
     assert latitude_cut.size == 9
@@ -202,7 +202,7 @@ def test_inside_latlon_0_360():
     assert set(latitude_cut) == set([-10, 0, 10])
     # Check region longitudes in -180, 180
     region = 170, -170, -10, 10
-    are_inside = inside([longitude, latitude], region, latlon=True)
+    are_inside = inside([longitude, latitude], region, geographic=True)
     longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
     assert longitude_cut.size == 9
     assert latitude_cut.size == 9
@@ -210,7 +210,7 @@ def test_inside_latlon_0_360():
     assert set(latitude_cut) == set([-10, 0, 10])
     # Check region longitudes around zero meridian
     region = -10, 10, -10, 10
-    are_inside = inside([longitude, latitude], region, latlon=True)
+    are_inside = inside([longitude, latitude], region, geographic=True)
     longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
     assert longitude_cut.size == 9
     assert latitude_cut.size == 9
@@ -218,7 +218,7 @@ def test_inside_latlon_0_360():
     assert set(latitude_cut) == set([-10, 0, 10])
 
 
-def test_inside_latlon_180_180():
+def test_inside_geographic_180_180():
     "Check if inside gets points properly with geographic coordinates on [-180, 180]"
     # Define longitude coordinates on -180, 180
     longitude = np.linspace(-170, 180, 36)
@@ -226,7 +226,7 @@ def test_inside_latlon_180_180():
     longitude, latitude = np.meshgrid(longitude, latitude)
     # Check region longitudes in 0, 360
     region = 20, 40, -10, 10
-    are_inside = inside([longitude, latitude], region, latlon=True)
+    are_inside = inside([longitude, latitude], region, geographic=True)
     longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
     assert longitude_cut.size == 9
     assert latitude_cut.size == 9
@@ -234,7 +234,7 @@ def test_inside_latlon_180_180():
     assert set(latitude_cut) == set([-10, 0, 10])
     # Check region longitudes in 0, 360 around 180
     region = 170, 190, -10, 10
-    are_inside = inside([longitude, latitude], region, latlon=True)
+    are_inside = inside([longitude, latitude], region, geographic=True)
     longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
     assert longitude_cut.size == 9
     assert latitude_cut.size == 9
@@ -242,7 +242,7 @@ def test_inside_latlon_180_180():
     assert set(latitude_cut) == set([-10, 0, 10])
     # Check region longitudes in -180, 180
     region = 170, -170, -10, 10
-    are_inside = inside([longitude, latitude], region, latlon=True)
+    are_inside = inside([longitude, latitude], region, geographic=True)
     longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
     assert longitude_cut.size == 9
     assert latitude_cut.size == 9
@@ -250,7 +250,7 @@ def test_inside_latlon_180_180():
     assert set(latitude_cut) == set([-10, 0, 10])
     # Check region longitudes around zero meridian
     region = -10, 10, -10, 10
-    are_inside = inside([longitude, latitude], region, latlon=True)
+    are_inside = inside([longitude, latitude], region, geographic=True)
     longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
     assert longitude_cut.size == 9
     assert latitude_cut.size == 9
@@ -258,13 +258,13 @@ def test_inside_latlon_180_180():
     assert set(latitude_cut) == set([-10, 0, 10])
 
 
-def test_inside_latlon_around_poles():
+def test_inside_geographic_around_poles():
     "Test inside function when region is around the poles"
     longitude, latitude = grid_coordinates([0, 350, -90, 90], spacing=10.0)
     # North Pole all around the globe
     regions = [[0, 360, 70, 90], [-180, 180, 70, 90]]
     for region in regions:
-        are_inside = inside([longitude, latitude], region, latlon=True)
+        are_inside = inside([longitude, latitude], region, geographic=True)
         assert longitude[are_inside].size == 3 * 36
         assert latitude[are_inside].size == 3 * 36
         assert set(longitude[are_inside]) == set(np.unique(longitude))
@@ -272,33 +272,33 @@ def test_inside_latlon_around_poles():
     # South Pole all around the globe
     regions = [[0, 360, -90, -70], [-180, 180, -90, -70]]
     for region in regions:
-        are_inside = inside([longitude, latitude], region, latlon=True)
+        are_inside = inside([longitude, latitude], region, geographic=True)
         assert longitude[are_inside].size == 3 * 36
         assert latitude[are_inside].size == 3 * 36
         assert set(longitude[are_inside]) == set(np.unique(longitude))
         assert set(latitude[are_inside]) == set([-90, -80, -70])
     # Section at the North Pole
     region = [40, 90, 70, 90]
-    are_inside = inside([longitude, latitude], region, latlon=True)
+    are_inside = inside([longitude, latitude], region, geographic=True)
     assert longitude[are_inside].size == 3 * 6
     assert latitude[are_inside].size == 3 * 6
     assert set(longitude[are_inside]) == set([40, 50, 60, 70, 80, 90])
     assert set(latitude[are_inside]) == set([70, 80, 90])
     region = [-90, -40, 70, 90]
-    are_inside = inside([longitude, latitude], region, latlon=True)
+    are_inside = inside([longitude, latitude], region, geographic=True)
     assert longitude[are_inside].size == 3 * 6
     assert latitude[are_inside].size == 3 * 6
     assert set(longitude[are_inside]) == set([270, 280, 290, 300, 310, 320])
     assert set(latitude[are_inside]) == set([70, 80, 90])
     # Section at the South Pole
     region = [40, 90, -90, -70]
-    are_inside = inside([longitude, latitude], region, latlon=True)
+    are_inside = inside([longitude, latitude], region, geographic=True)
     assert longitude[are_inside].size == 3 * 6
     assert latitude[are_inside].size == 3 * 6
     assert set(longitude[are_inside]) == set([40, 50, 60, 70, 80, 90])
     assert set(latitude[are_inside]) == set([-90, -80, -70])
     region = [-90, -40, -90, -70]
-    are_inside = inside([longitude, latitude], region, latlon=True)
+    are_inside = inside([longitude, latitude], region, geographic=True)
     assert longitude[are_inside].size == 3 * 6
     assert latitude[are_inside].size == 3 * 6
     assert set(longitude[are_inside]) == set([270, 280, 290, 300, 310, 320])

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -11,7 +11,7 @@ from ..coordinates import (
     profile_coordinates,
     grid_coordinates,
     inside,
-    _latlon_continuity,
+    latlon_continuity,
 )
 
 
@@ -123,7 +123,9 @@ def test_latlon_continuity():
     w, e = 10.5, 20.3
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        coordinates_new, region_new = _latlon_continuity(coordinates, (w, e, s, n))
+        region_new, coordinates_new = latlon_continuity(
+            (w, e, s, n), coordinates=coordinates
+        )
         w_new, e_new = region_new[:2]
         assert w_new == w
         assert e_new == e
@@ -132,7 +134,9 @@ def test_latlon_continuity():
     w, e = -20, 20
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        coordinates_new, region_new = _latlon_continuity(coordinates, (w, e, s, n))
+        region_new, coordinates_new = latlon_continuity(
+            (w, e, s, n), coordinates=coordinates
+        )
         w_new, e_new = region_new[:2]
         assert w_new == -20
         assert e_new == 20
@@ -141,7 +145,9 @@ def test_latlon_continuity():
     for w, e in [[0, 360], [-180, 180], [-20, 340]]:
         for longitude in [longitude_360, longitude_180]:
             coordinates = [longitude, latitude]
-            coordinates_new, region_new = _latlon_continuity(coordinates, (w, e, s, n))
+            region_new, coordinates_new = latlon_continuity(
+                (w, e, s, n), coordinates=coordinates
+            )
             w_new, e_new = region_new[:2]
             assert w_new == 0
             assert e_new == 360
@@ -150,7 +156,9 @@ def test_latlon_continuity():
     w, e = 20, 20
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        coordinates_new, region_new = _latlon_continuity(coordinates, (w, e, s, n))
+        region_new, coordinates_new = latlon_continuity(
+            (w, e, s, n), coordinates=coordinates
+        )
         w_new, e_new = region_new[:2]
         assert w_new == 20
         assert e_new == 20
@@ -159,7 +167,9 @@ def test_latlon_continuity():
     w, e = 0, 200
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        coordinates_new, region_new = _latlon_continuity(coordinates, (w, e, s, n))
+        region_new, coordinates_new = latlon_continuity(
+            (w, e, s, n), coordinates=coordinates
+        )
         w_new, e_new = region_new[:2]
         assert w_new == 0
         assert e_new == 200
@@ -167,7 +177,9 @@ def test_latlon_continuity():
     w, e = -160, 160
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        coordinates_new, region_new = _latlon_continuity(coordinates, (w, e, s, n))
+        region_new, coordinates_new = latlon_continuity(
+            (w, e, s, n), coordinates=coordinates
+        )
         w_new, e_new = region_new[:2]
         assert w_new == -160
         assert e_new == 160

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -118,6 +118,14 @@ def test_inside_latlon_0_360():
     assert latitude_cut.size == 9
     assert set(longitude_cut) == set([170, 180, 190])
     assert set(latitude_cut) == set([-10, 0, 10])
+    # Check region longitudes around zero meridian
+    region = -10, 10, -10, 10
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
+    assert longitude_cut.size == 9
+    assert latitude_cut.size == 9
+    assert set(longitude_cut) == set([0, 10, 350])
+    assert set(latitude_cut) == set([-10, 0, 10])
     # Check region longitudes greater than 360
     region = 380, 400, -10, 10
     are_inside = inside([longitude, latitude], region, latlon=True)
@@ -157,6 +165,14 @@ def test_inside_latlon_180_180():
     assert longitude_cut.size == 9
     assert latitude_cut.size == 9
     assert set(longitude_cut) == set([170, 180, -170])
+    assert set(latitude_cut) == set([-10, 0, 10])
+    # Check region longitudes around zero meridian
+    region = -10, 10, -10, 10
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
+    assert longitude_cut.size == 9
+    assert latitude_cut.size == 9
+    assert set(longitude_cut) == set([-10, 0, 10])
     assert set(latitude_cut) == set([-10, 0, 10])
     # Check region longitudes greater than 360
     region = 380, 400, -10, 10

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -87,21 +87,6 @@ def test_check_region():
         check_region([-1, -2, -4, -3])
     with pytest.raises(ValueError):
         check_region([-2, -1, -2, -3])
-    check_region([0, 360, -90, 90], geographic=True)
-    with pytest.raises(ValueError):
-        check_region([-200, 0, -10, 10], geographic=True)
-    with pytest.raises(ValueError):
-        check_region([0, 400, -10, 10], geographic=True)
-    with pytest.raises(ValueError):
-        check_region([-200, -190, -10, 10], geographic=True)
-    with pytest.raises(ValueError):
-        check_region([-45, 45, -100, 0], geographic=True)
-    with pytest.raises(ValueError):
-        check_region([-45, 45, -100, 0], geographic=True)
-    with pytest.raises(ValueError):
-        check_region([-45, 45, 0, 100], geographic=True)
-    with pytest.raises(ValueError):
-        check_region([-100, 260.5, -30, 30], geographic=True)
 
 
 def test_profile_coordiantes_fails():
@@ -123,9 +108,7 @@ def test_longitude_continuity():
     w, e = 10.5, 20.3
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region_new, coordinates_new = longitude_continuity(
-            (w, e, s, n), coordinates=coordinates
-        )
+        coordinates_new, region_new = longitude_continuity(coordinates, (w, e, s, n))
         w_new, e_new = region_new[:2]
         assert w_new == w
         assert e_new == e
@@ -134,9 +117,7 @@ def test_longitude_continuity():
     w, e = -20, 20
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region_new, coordinates_new = longitude_continuity(
-            (w, e, s, n), coordinates=coordinates
-        )
+        coordinates_new, region_new = longitude_continuity(coordinates, (w, e, s, n))
         w_new, e_new = region_new[:2]
         assert w_new == -20
         assert e_new == 20
@@ -145,8 +126,8 @@ def test_longitude_continuity():
     for w, e in [[0, 360], [-180, 180], [-20, 340]]:
         for longitude in [longitude_360, longitude_180]:
             coordinates = [longitude, latitude]
-            region_new, coordinates_new = longitude_continuity(
-                (w, e, s, n), coordinates=coordinates
+            coordinates_new, region_new = longitude_continuity(
+                coordinates, (w, e, s, n)
             )
             w_new, e_new = region_new[:2]
             assert w_new == 0
@@ -156,9 +137,7 @@ def test_longitude_continuity():
     w, e = 20, 20
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region_new, coordinates_new = longitude_continuity(
-            (w, e, s, n), coordinates=coordinates
-        )
+        coordinates_new, region_new = longitude_continuity(coordinates, (w, e, s, n))
         w_new, e_new = region_new[:2]
         assert w_new == 20
         assert e_new == 20
@@ -167,9 +146,7 @@ def test_longitude_continuity():
     w, e = 0, 200
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region_new, coordinates_new = longitude_continuity(
-            (w, e, s, n), coordinates=coordinates
-        )
+        coordinates_new, region_new = longitude_continuity(coordinates, (w, e, s, n))
         w_new, e_new = region_new[:2]
         assert w_new == 0
         assert e_new == 200
@@ -177,129 +154,8 @@ def test_longitude_continuity():
     w, e = -160, 160
     for longitude in [longitude_360, longitude_180]:
         coordinates = [longitude, latitude]
-        region_new, coordinates_new = longitude_continuity(
-            (w, e, s, n), coordinates=coordinates
-        )
+        coordinates_new, region_new = longitude_continuity(coordinates, (w, e, s, n))
         w_new, e_new = region_new[:2]
         assert w_new == -160
         assert e_new == 160
         npt.assert_allclose(coordinates_new[0], longitude_180)
-
-
-def test_inside_geographic_0_360():
-    "Check if inside gets points properly with geographic coordinates on [0, 360]"
-    # Define longitude coordinates on 0, 360
-    longitude = np.linspace(0, 350, 36)
-    latitude = np.linspace(-90, 90, 19)
-    longitude, latitude = np.meshgrid(longitude, latitude)
-    # Check region longitudes in 0, 360
-    region = 20, 40, -10, 10
-    are_inside = inside([longitude, latitude], region, geographic=True)
-    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
-    assert longitude_cut.size == 9
-    assert latitude_cut.size == 9
-    assert set(longitude_cut) == set([20, 30, 40])
-    assert set(latitude_cut) == set([-10, 0, 10])
-    # Check region longitudes in -180, 180
-    region = 170, -170, -10, 10
-    are_inside = inside([longitude, latitude], region, geographic=True)
-    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
-    assert longitude_cut.size == 9
-    assert latitude_cut.size == 9
-    assert set(longitude_cut) == set([170, 180, 190])
-    assert set(latitude_cut) == set([-10, 0, 10])
-    # Check region longitudes around zero meridian
-    region = -10, 10, -10, 10
-    are_inside = inside([longitude, latitude], region, geographic=True)
-    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
-    assert longitude_cut.size == 9
-    assert latitude_cut.size == 9
-    assert set(longitude_cut) == set([0, 10, 350])
-    assert set(latitude_cut) == set([-10, 0, 10])
-
-
-def test_inside_geographic_180_180():
-    "Check if inside gets points properly with geographic coordinates on [-180, 180]"
-    # Define longitude coordinates on -180, 180
-    longitude = np.linspace(-170, 180, 36)
-    latitude = np.linspace(-90, 90, 19)
-    longitude, latitude = np.meshgrid(longitude, latitude)
-    # Check region longitudes in 0, 360
-    region = 20, 40, -10, 10
-    are_inside = inside([longitude, latitude], region, geographic=True)
-    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
-    assert longitude_cut.size == 9
-    assert latitude_cut.size == 9
-    assert set(longitude_cut) == set([20, 30, 40])
-    assert set(latitude_cut) == set([-10, 0, 10])
-    # Check region longitudes in 0, 360 around 180
-    region = 170, 190, -10, 10
-    are_inside = inside([longitude, latitude], region, geographic=True)
-    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
-    assert longitude_cut.size == 9
-    assert latitude_cut.size == 9
-    assert set(longitude_cut) == set([170, 180, -170])
-    assert set(latitude_cut) == set([-10, 0, 10])
-    # Check region longitudes in -180, 180
-    region = 170, -170, -10, 10
-    are_inside = inside([longitude, latitude], region, geographic=True)
-    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
-    assert longitude_cut.size == 9
-    assert latitude_cut.size == 9
-    assert set(longitude_cut) == set([170, 180, -170])
-    assert set(latitude_cut) == set([-10, 0, 10])
-    # Check region longitudes around zero meridian
-    region = -10, 10, -10, 10
-    are_inside = inside([longitude, latitude], region, geographic=True)
-    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
-    assert longitude_cut.size == 9
-    assert latitude_cut.size == 9
-    assert set(longitude_cut) == set([-10, 0, 10])
-    assert set(latitude_cut) == set([-10, 0, 10])
-
-
-def test_inside_geographic_around_poles():
-    "Test inside function when region is around the poles"
-    longitude, latitude = grid_coordinates([0, 350, -90, 90], spacing=10.0)
-    # North Pole all around the globe
-    regions = [[0, 360, 70, 90], [-180, 180, 70, 90]]
-    for region in regions:
-        are_inside = inside([longitude, latitude], region, geographic=True)
-        assert longitude[are_inside].size == 3 * 36
-        assert latitude[are_inside].size == 3 * 36
-        assert set(longitude[are_inside]) == set(np.unique(longitude))
-        assert set(latitude[are_inside]) == set([70, 80, 90])
-    # South Pole all around the globe
-    regions = [[0, 360, -90, -70], [-180, 180, -90, -70]]
-    for region in regions:
-        are_inside = inside([longitude, latitude], region, geographic=True)
-        assert longitude[are_inside].size == 3 * 36
-        assert latitude[are_inside].size == 3 * 36
-        assert set(longitude[are_inside]) == set(np.unique(longitude))
-        assert set(latitude[are_inside]) == set([-90, -80, -70])
-    # Section at the North Pole
-    region = [40, 90, 70, 90]
-    are_inside = inside([longitude, latitude], region, geographic=True)
-    assert longitude[are_inside].size == 3 * 6
-    assert latitude[are_inside].size == 3 * 6
-    assert set(longitude[are_inside]) == set([40, 50, 60, 70, 80, 90])
-    assert set(latitude[are_inside]) == set([70, 80, 90])
-    region = [-90, -40, 70, 90]
-    are_inside = inside([longitude, latitude], region, geographic=True)
-    assert longitude[are_inside].size == 3 * 6
-    assert latitude[are_inside].size == 3 * 6
-    assert set(longitude[are_inside]) == set([270, 280, 290, 300, 310, 320])
-    assert set(latitude[are_inside]) == set([70, 80, 90])
-    # Section at the South Pole
-    region = [40, 90, -90, -70]
-    are_inside = inside([longitude, latitude], region, geographic=True)
-    assert longitude[are_inside].size == 3 * 6
-    assert latitude[are_inside].size == 3 * 6
-    assert set(longitude[are_inside]) == set([40, 50, 60, 70, 80, 90])
-    assert set(latitude[are_inside]) == set([-90, -80, -70])
-    region = [-90, -40, -90, -70]
-    are_inside = inside([longitude, latitude], region, geographic=True)
-    assert longitude[are_inside].size == 3 * 6
-    assert latitude[are_inside].size == 3 * 6
-    assert set(longitude[are_inside]) == set([270, 280, 290, 300, 310, 320])
-    assert set(latitude[are_inside]) == set([-90, -80, -70])

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -101,7 +101,7 @@ def test_check_region():
     with pytest.raises(ValueError):
         check_region([-45, 45, 0, 100], latlon=True)
     with pytest.raises(ValueError):
-        check_region([0, 360.5, -30, 30], latlon=True)
+        check_region([-100, 260.5, -30, 30], latlon=True)
 
 
 def test_profile_coordiantes_fails():

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -116,6 +116,13 @@ def test_latlon_continuity():
         assert w_new == -20
         assert e_new == 20
         npt.assert_allclose(longitude_new, longitude_180)
+    # Check region around the globe
+    w, e = 20, 380
+    for longitude in [longitude_360, longitude_180]:
+        w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
+        assert w_new == 0
+        assert e_new == 360
+        npt.assert_allclose(longitude_new, longitude_360)
     # Check angle greater than 180
     w, e = 0, 200
     for longitude in [longitude_360, longitude_180]:

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -1,6 +1,7 @@
 """
 Test the coordinate generation functions
 """
+import numpy as np
 import numpy.testing as npt
 import pytest
 
@@ -9,6 +10,7 @@ from ..coordinates import (
     spacing_to_shape,
     profile_coordinates,
     grid_coordinates,
+    inside,
 )
 
 
@@ -92,3 +94,75 @@ def test_profile_coordiantes_fails():
         profile_coordinates((0, 1), (1, 2), size=0)
     with pytest.raises(ValueError):
         profile_coordinates((0, 1), (1, 2), size=-10)
+
+
+def test_inside_latlon_0_360():
+    "Check if inside gets points properly with geographic coordinates on [0, 360]"
+    # Define longitude coordinates on 0, 360
+    longitude = np.linspace(0, 350, 36)
+    latitude = np.linspace(-90, 90, 19)
+    longitude, latitude = np.meshgrid(longitude, latitude)
+    # Check region longitudes in 0, 360
+    region = 20, 40, -10, 10
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
+    assert longitude_cut.size == 9
+    assert latitude_cut.size == 9
+    assert set(longitude_cut) == set([20, 30, 40])
+    assert set(latitude_cut) == set([-10, 0, 10])
+    # Check region longitudes in -180, 180
+    region = 170, -170, -10, 10
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
+    assert longitude_cut.size == 9
+    assert latitude_cut.size == 9
+    assert set(longitude_cut) == set([170, 180, 190])
+    assert set(latitude_cut) == set([-10, 0, 10])
+    # Check region longitudes greater than 360
+    region = 380, 400, -10, 10
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
+    assert longitude_cut.size == 9
+    assert latitude_cut.size == 9
+    assert set(longitude_cut) == set([20, 30, 40])
+    assert set(latitude_cut) == set([-10, 0, 10])
+
+
+def test_inside_latlon_180_180():
+    "Check if inside gets points properly with geographic coordinates on [-180, 180]"
+    # Define longitude coordinates on -180, 180
+    longitude = np.linspace(-170, 180, 36)
+    latitude = np.linspace(-90, 90, 19)
+    longitude, latitude = np.meshgrid(longitude, latitude)
+    # Check region longitudes in 0, 360
+    region = 20, 40, -10, 10
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
+    assert longitude_cut.size == 9
+    assert latitude_cut.size == 9
+    assert set(longitude_cut) == set([20, 30, 40])
+    assert set(latitude_cut) == set([-10, 0, 10])
+    # Check region longitudes in 0, 360 around 180
+    region = 170, 190, -10, 10
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
+    assert longitude_cut.size == 9
+    assert latitude_cut.size == 9
+    assert set(longitude_cut) == set([170, 180, -170])
+    assert set(latitude_cut) == set([-10, 0, 10])
+    # Check region longitudes in -180, 180
+    region = 170, -170, -10, 10
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
+    assert longitude_cut.size == 9
+    assert latitude_cut.size == 9
+    assert set(longitude_cut) == set([170, 180, -170])
+    assert set(latitude_cut) == set([-10, 0, 10])
+    # Check region longitudes greater than 360
+    region = 380, 400, -10, 10
+    are_inside = inside([longitude, latitude], region, latlon=True)
+    longitude_cut, latitude_cut = longitude[are_inside], latitude[are_inside]
+    assert longitude_cut.size == 9
+    assert latitude_cut.size == 9
+    assert set(longitude_cut) == set([20, 30, 40])
+    assert set(latitude_cut) == set([-10, 0, 10])

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -117,12 +117,12 @@ def test_latlon_continuity():
         assert e_new == 20
         npt.assert_allclose(longitude_new, longitude_180)
     # Check region around the globe
-    w, e = 20, 380
-    for longitude in [longitude_360, longitude_180]:
-        w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
-        assert w_new == 0
-        assert e_new == 360
-        npt.assert_allclose(longitude_new, longitude_360)
+    for w, e in [[0, 360], [-180, 180], [20, 380]]:
+        for longitude in [longitude_360, longitude_180]:
+            w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
+            assert w_new == 0
+            assert e_new == 360
+            npt.assert_allclose(longitude_new, longitude_360)
     # Check angle greater than 180
     w, e = 0, 200
     for longitude in [longitude_360, longitude_180]:

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -159,3 +159,21 @@ def test_longitude_continuity():
         assert w_new == -160
         assert e_new == 160
         npt.assert_allclose(coordinates_new[0], longitude_180)
+
+
+def test_invalid_geographic_region():
+    "Check if passing invalid region to longitude_continuity raises a ValueError"
+    # Region with latitude over boundaries
+    w, e = -10, 10
+    for s, n in [[-200, 90], [-90, 200]]:
+        with pytest.raises(ValueError):
+            longitude_continuity(None, [w, e, s, n])
+    # Region with longitude over boundaries
+    s, n = -10, 10
+    for w, e in [[-200, 0], [0, 380]]:
+        with pytest.raises(ValueError):
+            longitude_continuity(None, [w, e, s, n])
+    # Region with longitudinal difference greater than 360
+    w, e, s, n = -180, 200, -10, 10
+    with pytest.raises(ValueError):
+        longitude_continuity(None, [w, e, s, n])

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -123,6 +123,13 @@ def test_latlon_continuity():
             assert w_new == 0
             assert e_new == 360
             npt.assert_allclose(longitude_new, longitude_360)
+    # Check w == e
+    w, e = 20, 20
+    for longitude in [longitude_360, longitude_180]:
+        w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
+        assert w_new == 20
+        assert e_new == 20
+        npt.assert_allclose(longitude_new, longitude_360)
     # Check angle greater than 180
     w, e = 0, 200
     for longitude in [longitude_360, longitude_180]:

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -11,7 +11,7 @@ from ..coordinates import (
     profile_coordinates,
     grid_coordinates,
     inside,
-    latlon_continuity,
+    _latlon_continuity,
 )
 
 
@@ -101,23 +101,23 @@ def test_latlon_continuity():
     "Test continuous boundary conditions in geographic coordinates."
     # Two longitude coordinates in [0, 360]
     longitude = np.array([10, 170])
-    npt.assert_allclose(latlon_continuity(longitude), longitude)
+    npt.assert_allclose(_latlon_continuity(longitude), longitude)
     # Two longitude coordinates in [0, 360] with difference > 180 degrees
     longitude = np.array([10, 350])
     expected_longitude = np.array([10, -10])
-    npt.assert_allclose(latlon_continuity(longitude), expected_longitude)
+    npt.assert_allclose(_latlon_continuity(longitude), expected_longitude)
     # Two longitude coordinates in [-180, 180]
     longitude = np.array([-50, 50])
-    npt.assert_allclose(latlon_continuity(longitude), longitude)
+    npt.assert_allclose(_latlon_continuity(longitude), longitude)
     # Two longitude coordinates in [-180, 180] with difference > 180 degrees
     longitude = np.array([170, -170])
     expected_longitude = np.array([170, 190])
-    npt.assert_allclose(latlon_continuity(longitude), expected_longitude)
+    npt.assert_allclose(_latlon_continuity(longitude), expected_longitude)
     # Extra coordinates in [0, 360]
     longitude = np.array([10, 170])
     extra = np.linspace(0, 350, 36)
     for result, expected in zip(
-        latlon_continuity(longitude, extra_coords=extra), [longitude, extra]
+        _latlon_continuity(longitude, extra_coords=extra), [longitude, extra]
     ):
         npt.assert_allclose(result, expected)
     # Extra coordinates in [0, 360] with difference > 180 degrees
@@ -125,14 +125,14 @@ def test_latlon_continuity():
     extra = np.linspace(0, 350, 36)
     expected_arrays = [np.array([10, -10]), np.hstack((extra[:18], extra[18:] - 360))]
     for result, expected in zip(
-        latlon_continuity(longitude, extra_coords=extra), expected_arrays
+        _latlon_continuity(longitude, extra_coords=extra), expected_arrays
     ):
         npt.assert_allclose(result, expected)
     # Extra coordinates in [-180, 180]
     longitude = np.array([-50, 50])
     extra = np.linspace(-180, 170, 36)
     for result, expected in zip(
-        latlon_continuity(longitude, extra_coords=extra), [longitude, extra]
+        _latlon_continuity(longitude, extra_coords=extra), [longitude, extra]
     ):
         npt.assert_allclose(result, expected)
     # Extra coordinates in [-180, 180] with difference > 180 degrees
@@ -140,7 +140,7 @@ def test_latlon_continuity():
     extra = np.linspace(-180, 170, 36)
     expected_arrays = [np.array([170, 190]), np.hstack((extra[:18] + 360, extra[18:]))]
     for result, expected in zip(
-        latlon_continuity(longitude, extra_coords=extra), expected_arrays
+        _latlon_continuity(longitude, extra_coords=extra), expected_arrays
     ):
         npt.assert_allclose(result, expected)
 

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -117,7 +117,7 @@ def test_latlon_continuity():
         assert e_new == 20
         npt.assert_allclose(longitude_new, longitude_180)
     # Check region around the globe
-    for w, e in [[0, 360], [-180, 180], [20, 380]]:
+    for w, e in [[0, 360], [-180, 180], [20, 380], [0, 360 * 2]]:
         for longitude in [longitude_360, longitude_180]:
             w_new, e_new, longitude_new = _latlon_continuity(w, e, longitude)
             assert w_new == 0


### PR DESCRIPTION
Add `latlon_continuity()` function that moves a set of longitudinal coordinates either
to the `[0, 360)` or `[-180, 180)` degrees intervals, depending which one is more suited for
that particular set of coordinates.
It also allow to modify an extra set of coordinates based on the decision made on the
first set.
Modify the `inside()` function to enhance how the inside points are selected, even if
their longitudinal coordinates are not defined on the same degree interval. 

Fixes #171 

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
