### PR TITLE
Fix wrong coordinates for pixel-register and shape

### DIFF
--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -244,7 +244,8 @@ def grid_coordinates(
     pixel_register : bool
         If True, the coordinates will refer to the center of each grid pixel instead of
         the grid lines. In practice, this means that there will be one less element per
-        dimension of the grid when compared to grid line registered. Default is False.
+        dimension of the grid when compared to grid line registered (only if given
+        *spacing* and not *shape*). Default is False.
     extra_coords : None, scalar, or list
         If not None, then value(s) of extra coordinate arrays to be generated. These
         extra arrays will have the same *shape* as the others but will contain a
@@ -279,8 +280,10 @@ def grid_coordinates(
      [ 5.   5.   5. ]
      [ 7.5  7.5  7.5]
      [10.  10.  10. ]]
-    >>> # The grid can also be specified using the spacing between points
-    >>> # instead of the shape.
+
+    The grid can also be specified using the spacing between points instead of the
+    shape:
+
     >>> east, north = grid_coordinates(region=(0, 5, 0, 10), spacing=2.5)
     >>> print(east.shape, north.shape)
     (5, 3) (5, 3)
@@ -296,7 +299,113 @@ def grid_coordinates(
      [ 5.   5.   5. ]
      [ 7.5  7.5  7.5]
      [10.  10.  10. ]]
-    >>> # Generate arrays for other coordinates that have a constant value.
+
+    The spacing can be different for northing and easting, respectively:
+
+    >>> east, north = grid_coordinates(region=(-5, 1, 0, 10), spacing=(2.5, 1))
+    >>> print(east.shape, north.shape)
+    (5, 7) (5, 7)
+    >>> print(east)
+    [[-5. -4. -3. -2. -1.  0.  1.]
+     [-5. -4. -3. -2. -1.  0.  1.]
+     [-5. -4. -3. -2. -1.  0.  1.]
+     [-5. -4. -3. -2. -1.  0.  1.]
+     [-5. -4. -3. -2. -1.  0.  1.]]
+    >>> print(north)
+    [[ 0.   0.   0.   0.   0.   0.   0. ]
+     [ 2.5  2.5  2.5  2.5  2.5  2.5  2.5]
+     [ 5.   5.   5.   5.   5.   5.   5. ]
+     [ 7.5  7.5  7.5  7.5  7.5  7.5  7.5]
+     [10.  10.  10.  10.  10.  10.  10. ]]
+
+    If the region can't be divided into the desired spacing, the spacing will be
+    adjusted to conform to the region:
+
+    >>> east, north = grid_coordinates(region=(-5, 0, 0, 5), spacing=2.6)
+    >>> print(east.shape, north.shape)
+    (3, 3) (3, 3)
+    >>> print(east)
+    [[-5.  -2.5  0. ]
+     [-5.  -2.5  0. ]
+     [-5.  -2.5  0. ]]
+    >>> print(north)
+    [[0.  0.  0. ]
+     [2.5 2.5 2.5]
+     [5.  5.  5. ]]
+    >>> east, north = grid_coordinates(region=(-5, 0, 0, 5), spacing=2.4)
+    >>> print(east.shape, north.shape)
+    (3, 3) (3, 3)
+    >>> print(east)
+    [[-5.  -2.5  0. ]
+     [-5.  -2.5  0. ]
+     [-5.  -2.5  0. ]]
+    >>> print(north)
+    [[0.  0.  0. ]
+     [2.5 2.5 2.5]
+     [5.  5.  5. ]]
+
+    You can choose to adjust the East and North boundaries of the region instead:
+
+    >>> east, north = grid_coordinates(region=(-5, 0, 0, 5), spacing=2.6,
+    ...                                adjust='region')
+    >>> print(east.shape, north.shape)
+    (3, 3) (3, 3)
+    >>> print(east)
+    [[-5.  -2.4  0.2]
+     [-5.  -2.4  0.2]
+     [-5.  -2.4  0.2]]
+    >>> print(north)
+    [[0.  0.  0. ]
+     [2.6 2.6 2.6]
+     [5.2 5.2 5.2]]
+    >>> east, north = grid_coordinates(region=(-5, 0, 0, 5), spacing=2.4,
+    ...                                adjust='region')
+    >>> print(east.shape, north.shape)
+    (3, 3) (3, 3)
+    >>> print(east)
+    [[-5.  -2.6 -0.2]
+     [-5.  -2.6 -0.2]
+     [-5.  -2.6 -0.2]]
+    >>> print(north)
+    [[0.  0.  0. ]
+     [2.4 2.4 2.4]
+     [4.8 4.8 4.8]]
+
+    We can optionally generate coordinates for the center of each grid pixel instead of
+    the corner (default):
+
+    >>> east, north = grid_coordinates(region=(0, 5, 0, 10), spacing=2.5,
+    ...                                pixel_register=True)
+    >>> # Raise the printing precision for this example
+    >>> np.set_printoptions(precision=2, suppress=True)
+    >>> # Notice that the shape is 1 less than when pixel_register=False
+    >>> print(east.shape, north.shape)
+    (4, 2) (4, 2)
+    >>> print(east)
+    [[1.25 3.75]
+     [1.25 3.75]
+     [1.25 3.75]
+     [1.25 3.75]]
+    >>> print(north)
+    [[1.25 1.25]
+     [3.75 3.75]
+     [6.25 6.25]
+     [8.75 8.75]]
+    >>> east, north = grid_coordinates(region=(0, 5, 0, 10), shape=(4, 2),
+    ...                                pixel_register=True)
+    >>> print(east)
+    [[1.25 3.75]
+     [1.25 3.75]
+     [1.25 3.75]
+     [1.25 3.75]]
+    >>> print(north)
+    [[1.25 1.25]
+     [3.75 3.75]
+     [6.25 6.25]
+     [8.75 8.75]]
+
+    Generate arrays for other coordinates that have a constant value:
+
     >>> east, north, height = grid_coordinates(region=(0, 5, 0, 10), spacing=2.5,
     ...                                        extra_coords=57)
     >>> print(east.shape, north.shape, height.shape)
@@ -323,90 +432,6 @@ def grid_coordinates(
      [0.1 0.1 0.1]
      [0.1 0.1 0.1]
      [0.1 0.1 0.1]]
-    >>> # The spacing can be different for northing and easting, respectively
-    >>> east, north = grid_coordinates(region=(-5, 1, 0, 10), spacing=(2.5, 1))
-    >>> print(east.shape, north.shape)
-    (5, 7) (5, 7)
-    >>> print(east)
-    [[-5. -4. -3. -2. -1.  0.  1.]
-     [-5. -4. -3. -2. -1.  0.  1.]
-     [-5. -4. -3. -2. -1.  0.  1.]
-     [-5. -4. -3. -2. -1.  0.  1.]
-     [-5. -4. -3. -2. -1.  0.  1.]]
-    >>> print(north)
-    [[ 0.   0.   0.   0.   0.   0.   0. ]
-     [ 2.5  2.5  2.5  2.5  2.5  2.5  2.5]
-     [ 5.   5.   5.   5.   5.   5.   5. ]
-     [ 7.5  7.5  7.5  7.5  7.5  7.5  7.5]
-     [10.  10.  10.  10.  10.  10.  10. ]]
-    >>> # If the region can't be divided into the desired spacing, the spacing
-    >>> # will be adjusted to conform to the region
-    >>> east, north = grid_coordinates(region=(-5, 0, 0, 5), spacing=2.6)
-    >>> print(east.shape, north.shape)
-    (3, 3) (3, 3)
-    >>> print(east)
-    [[-5.  -2.5  0. ]
-     [-5.  -2.5  0. ]
-     [-5.  -2.5  0. ]]
-    >>> print(north)
-    [[0.  0.  0. ]
-     [2.5 2.5 2.5]
-     [5.  5.  5. ]]
-    >>> east, north = grid_coordinates(region=(-5, 0, 0, 5), spacing=2.4)
-    >>> print(east.shape, north.shape)
-    (3, 3) (3, 3)
-    >>> print(east)
-    [[-5.  -2.5  0. ]
-     [-5.  -2.5  0. ]
-     [-5.  -2.5  0. ]]
-    >>> print(north)
-    [[0.  0.  0. ]
-     [2.5 2.5 2.5]
-     [5.  5.  5. ]]
-    >>> # You can also choose to adjust the East and North boundaries of the
-    >>> # region instead.
-    >>> east, north = grid_coordinates(region=(-5, 0, 0, 5), spacing=2.6,
-    ...                                adjust='region')
-    >>> print(east.shape, north.shape)
-    (3, 3) (3, 3)
-    >>> print(east)
-    [[-5.  -2.4  0.2]
-     [-5.  -2.4  0.2]
-     [-5.  -2.4  0.2]]
-    >>> print(north)
-    [[0.  0.  0. ]
-     [2.6 2.6 2.6]
-     [5.2 5.2 5.2]]
-    >>> east, north = grid_coordinates(region=(-5, 0, 0, 5), spacing=2.4,
-    ...                                adjust='region')
-    >>> print(east.shape, north.shape)
-    (3, 3) (3, 3)
-    >>> print(east)
-    [[-5.  -2.6 -0.2]
-     [-5.  -2.6 -0.2]
-     [-5.  -2.6 -0.2]]
-    >>> print(north)
-    [[0.  0.  0. ]
-     [2.4 2.4 2.4]
-     [4.8 4.8 4.8]]
-    >>> # We can optionally generate coordinates for the center of each grid
-    >>> # pixel instead of the corner (default)
-    >>> east, north = grid_coordinates(region=(0, 5, 0, 10), spacing=2.5,
-    ...                                pixel_register=True)
-    >>> # Lower printing precision to shorten this example
-    >>> import numpy as np; np.set_printoptions(precision=2, suppress=True)
-    >>> print(east.shape, north.shape)
-    (4, 2) (4, 2)
-    >>> print(east)
-    [[1.25 3.75]
-     [1.25 3.75]
-     [1.25 3.75]
-     [1.25 3.75]]
-    >>> print(north)
-    [[1.25 1.25]
-     [3.75 3.75]
-     [6.25 6.25]
-     [8.75 8.75]]
 
     See also
     --------
@@ -421,6 +446,11 @@ def grid_coordinates(
         raise ValueError("Either a grid shape or a spacing must be provided.")
     if spacing is not None:
         shape, region = spacing_to_shape(region, spacing, adjust)
+    elif pixel_register:
+        # Starts by generating grid-line registered coordinates and shifting them to the
+        # center of the pixel. Need 1 more point if given a shape so that we can do
+        # that because we discard the last point when shifting the coordinates.
+        shape = tuple(i + 1 for i in shape)
     east_lines = np.linspace(region[0], region[1], shape[1])
     north_lines = np.linspace(region[2], region[3], shape[0])
     if pixel_register:


### PR DESCRIPTION
Fix a bug in `grid_coordinates` when passing `pixel_register=True` and
`shape` instead of `spacing`. The returned coordinates had 1 too few
elements in each dimension (and the wrong values). This is because we
generate grid-line registered points first and then shift them to the
center of the pixels and drop the last point. This only works when
specifying `spacing` because it will generate the right amount of
points. When `shape` is given, we need to first convert it to
"grid-line" shape (with 1 extra point per dimension) before generating
coordinates.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.