### PR TITLE
Add SplineCV: a cross-validated Spline

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -14,6 +14,7 @@ Interpolators
    :toctree: generated/
 
     Spline
+    SplineCV
     VectorSpline2D
     ScipyGridder
 

--- a/examples/spline_cv.py
+++ b/examples/spline_cv.py
@@ -1,0 +1,79 @@
+"""
+Gridding with splines (cross-validated)
+=======================================
+
+The :class:`verde.Spline` has two main parameters that need to be configured:
+
+1. ``mindist``: the minimum distance between forces and data points
+2. ``damping``: the regularization parameter controlling smoothness
+
+These parameters can be determined through cross-validation (see :ref:`model_selection`)
+automatically using :class:`verde.SplineCV`. It is very similar to :class:`verde.Spline`
+but takes a set of parameter values instead of only one value. When calling
+:meth:`verde.SplineCV.fit`, the class will:
+
+1. Create a spline for each combination of the input parameter sets
+2. Calculate the cross-validation score for each spline using
+   :func:`verde.cross_val_score`
+3. Pick the spline with the highest score
+
+"""
+import matplotlib.pyplot as plt
+import cartopy.crs as ccrs
+import pyproj
+import numpy as np
+import verde as vd
+
+# We'll test this on the air temperature data from Texas
+data = vd.datasets.fetch_texas_wind()
+coordinates = (data.longitude.values, data.latitude.values)
+region = vd.get_region(coordinates)
+
+# Use a Mercator projection for our Cartesian gridder
+projection = pyproj.Proj(proj="merc", lat_ts=data.latitude.mean())
+
+# The output grid spacing will 15 arc-minutes
+spacing = 15 / 60
+
+# This spline will automatically perform cross-validation and search for the optimal
+# parameter configuration.
+spline = vd.SplineCV(dampings=(1e-5, 1e-3, 1e-1), mindists=(10e3, 50e3, 100e3))
+
+# Fit the model on the data. Under the hood, the class will perform K-fold
+# cross-validation for each the 3*3=9 parameter combinations and pick the one with the
+# highest R² score.
+spline.fit(projection(*coordinates), data.air_temperature_c)
+
+# We can show the best R² score obtained in the cross-validation
+print("\nScore: {:.3f}".format(spline.scores_.max()))
+
+# And then the best spline parameters that produced this high score.
+print("\nBest spline configuration:")
+print(spline.best_)
+
+# Now we can create a geographic grid of air temperature by providing a projection
+# function to the grid method and mask points that are too far from the observations
+grid_full = spline.grid(
+    region=region,
+    spacing=spacing,
+    projection=projection,
+    dims=["latitude", "longitude"],
+    data_names=["temperature"],
+)
+grid = vd.distance_mask(
+    coordinates, maxdist=3 * spacing * 111e3, grid=grid_full, projection=projection
+)
+
+# Plot the grid and the original data points
+plt.figure(figsize=(8, 6))
+ax = plt.axes(projection=ccrs.Mercator())
+ax.set_title("Air temperature gridded with biharmonic spline")
+ax.plot(*coordinates, ".k", markersize=1, transform=ccrs.PlateCarree())
+tmp = grid.temperature.plot.pcolormesh(
+    ax=ax, cmap="plasma", transform=ccrs.PlateCarree(), add_colorbar=False
+)
+plt.colorbar(tmp).set_label("Air temperature (C)")
+# Use an utility function to add tick labels and land and ocean features to the map.
+vd.datasets.setup_texas_wind_map(ax, region=region)
+plt.tight_layout()
+plt.show()

--- a/examples/spline_cv.py
+++ b/examples/spline_cv.py
@@ -49,7 +49,8 @@ print("\nScore: {:.3f}".format(spline.scores_.max()))
 
 # And then the best spline parameters that produced this high score.
 print("\nBest spline configuration:")
-print(spline.best_)
+print("  mindist:", spline.mindist_)
+print("  damping:", spline.damping_)
 
 # Now we can create a geographic grid of air temperature by providing a projection
 # function to the grid method and mask points that are too far from the observations

--- a/tutorials/overview.py
+++ b/tutorials/overview.py
@@ -25,17 +25,15 @@ Before we get started, here are a few of the conventions we use across Verde:
 * The term "region" means the bounding box of the data. It is ordered west, east, south,
   north.
 
+The library
+-----------
+
+Most classes and functions are available through the :mod:`verde` top level package.
+The only exceptions are the functions related to loading sample data, which are in
+:mod:`verde.datasets`. Throughout the documentation we'll use ``vd`` as the alias for
+:mod:`verde`.
+
 """
-
-########################################################################################
-# The library
-# -----------
-#
-# Most classes and functions are available through the :mod:`verde` top level package.
-# The only exceptions are the functions related to loading sample data, which are in
-# :mod:`verde.datasets`. Throughout the documentation we'll use ``vd`` as the alias for
-# :mod:`verde`.
-
 import verde as vd
 
 ########################################################################################

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -19,7 +19,7 @@ from .blockreduce import BlockReduce, BlockMean
 from .scipygridder import ScipyGridder
 from .trend import Trend
 from .chain import Chain
-from .spline import Spline
+from .spline import Spline, SplineCV
 from .model_selection import cross_val_score, train_test_split
 from .vector import Vector, VectorSpline2D
 

--- a/verde/model_selection.py
+++ b/verde/model_selection.py
@@ -167,10 +167,11 @@ def cross_val_score(estimator, coordinates, data, weights=None, cv=None, client=
     >>> print(', '.join(['{:.2f}'.format(score) for score in scores]))
     1.00, 1.00, 1.00, 1.00, 1.00
 
-    >>> # To run parallel, we need to create a dask.distributed Client. It will
-    >>> # create a local cluster if no arguments are given so we can run the
-    >>> # scoring on a single machine. We'll use threads instead of processes for this
-    >>> # example but in most cases you'll want processes.
+    To run parallel, we need to create a :class:`dask.distributed.Client`. It will
+    create a local cluster if no arguments are given so we can run the scoring on a
+    single machine. We'll use threads instead of processes for this example but in most
+    cases you'll want processes.
+
     >>> from dask.distributed import Client
     >>> client = Client(processes=False)
     >>> # The scoring will now only submit tasks to our local cluster
@@ -181,6 +182,8 @@ def cross_val_score(estimator, coordinates, data, weights=None, cv=None, client=
     >>> # We need to call .result() to get back the actual value
     >>> print('{:.2f}'.format(scores[0].result()))
     1.00
+    >>> # Close the client and shutdown the local cluster
+    >>> client.close()
 
     """
     coordinates, data, weights = check_fit_input(

--- a/verde/model_selection.py
+++ b/verde/model_selection.py
@@ -18,12 +18,18 @@ class DummyClient:  # pylint: disable=no-self-use,too-few-public-methods
     >>> client = DummyClient()
     >>> client.submit(sum, (1, 2, 3))
     6
+    >>> print(client.scatter("bla"))
+    bla
 
     """
 
     def submit(self, function, *args, **kwargs):
         "Execute function with the given arguments and return its output"
         return function(*args, **kwargs)
+
+    def scatter(self, value):
+        "Does nothing but return the input"
+        return value
 
 
 def train_test_split(coordinates, data, weights=None, **kwargs):

--- a/verde/spline.py
+++ b/verde/spline.py
@@ -100,6 +100,7 @@ class SplineCV(BaseGridder):
         cv=None,
         client=None,
     ):
+        super().__init__()
         self.dampings = dampings
         self.mindists = mindists
         self.force_coords = force_coords

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -58,14 +58,16 @@ def test_spline_cv_parallel():
     synth = CheckerBoard(region=region)
     data = synth.scatter(size=1500, random_state=1)
     coords = (data.easting, data.northing)
+    client = Client(processes=False)
     # Can't test on many configurations because it takes too long for regular testing
     # Use ShuffleSplit instead of KFold to test it out and make this run faster
     spline = SplineCV(
         dampings=[None],
         mindists=[1e-5, 1e-3],
-        client=Client(processes=False),
+        client=client,
         cv=ShuffleSplit(n_splits=1, random_state=0),
     ).fit(coords, data.scalars)
+    client.close()
     # The interpolation should be perfect on top of the data points
     npt.assert_allclose(spline.predict(coords), data.scalars, rtol=1e-5)
     npt.assert_allclose(spline.score(coords, data.scalars), 1)

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -5,14 +5,73 @@ import warnings
 
 import numpy as np
 import numpy.testing as npt
+from sklearn.model_selection import ShuffleSplit
 
-from ..spline import Spline
+
+from ..spline import Spline, SplineCV
 from ..datasets.synthetic import CheckerBoard
-from .utils import requires_numba
+from .utils import requires_numba, requires_dask
+
+
+def test_spline_cv():
+    "See if the cross-validated spline solution matches the synthetic data"
+    region = (100, 500, -800, -700)
+    synth = CheckerBoard(region=region)
+    data = synth.scatter(size=1500, random_state=1)
+    coords = (data.easting, data.northing)
+    # Can't test on many configurations because it takes too long for regular testing
+    spline = SplineCV(dampings=[None], mindists=[1e-5, 1e-3]).fit(coords, data.scalars)
+    # The interpolation should be perfect on top of the data points
+    npt.assert_allclose(spline.predict(coords), data.scalars, rtol=1e-5)
+    npt.assert_allclose(spline.score(coords, data.scalars), 1)
+    assert spline.mindist_ == 1e-3
+    assert spline.damping_ is None
+    shape = (5, 5)
+    region = (270, 320, -770, -720)
+    # Tolerance needs to be kind of high to allow for error due to small
+    # dataset
+    npt.assert_allclose(
+        spline.grid(region, shape=shape).scalars,
+        synth.grid(region, shape=shape).scalars,
+        rtol=5e-2,
+    )
+
+
+@requires_dask
+def test_spline_cv_parallel():
+    "See if the parallel version of SplineCV works"
+    from dask.distributed import Client
+
+    region = (100, 500, -800, -700)
+    synth = CheckerBoard(region=region)
+    data = synth.scatter(size=1500, random_state=1)
+    coords = (data.easting, data.northing)
+    # Can't test on many configurations because it takes too long for regular testing
+    # Use ShuffleSplit instead of KFold to test it out and make this run faster
+    spline = SplineCV(
+        dampings=[None],
+        mindists=[1e-5, 1e-3],
+        client=Client(processes=False),
+        cv=ShuffleSplit(n_splits=1, random_state=0),
+    ).fit(coords, data.scalars)
+    # The interpolation should be perfect on top of the data points
+    npt.assert_allclose(spline.predict(coords), data.scalars, rtol=1e-5)
+    npt.assert_allclose(spline.score(coords, data.scalars), 1)
+    assert spline.mindist_ == 1e-5
+    assert spline.damping_ is None
+    shape = (5, 5)
+    region = (270, 320, -770, -720)
+    # Tolerance needs to be kind of high to allow for error due to small
+    # dataset
+    npt.assert_allclose(
+        spline.grid(region, shape=shape).scalars,
+        synth.grid(region, shape=shape).scalars,
+        rtol=5e-2,
+    )
 
 
 def test_spline():
-    "See if the exact spline solution."
+    "See if the exact spline solution matches the synthetic data"
     region = (100, 500, -800, -700)
     synth = CheckerBoard(region=region)
     data = synth.scatter(size=1500, random_state=1)

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -26,6 +26,18 @@ def test_spline_cv():
     npt.assert_allclose(spline.score(coords, data.scalars), 1)
     assert spline.mindist_ == 1e-3
     assert spline.damping_ is None
+    npt.assert_allclose(spline.force_coords, coords)
+    # There should be 1 force per data point
+    assert data.scalars.size == spline.force_.size
+    npt.assert_allclose(
+        spline.region_,
+        (
+            data.easting.min(),
+            data.easting.max(),
+            data.northing.min(),
+            data.northing.max(),
+        ),
+    )
     shape = (5, 5)
     region = (270, 320, -770, -720)
     # Tolerance needs to be kind of high to allow for error due to small

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -20,7 +20,11 @@ def test_spline_cv():
     data = synth.scatter(size=1500, random_state=1)
     coords = (data.easting, data.northing)
     # Can't test on many configurations because it takes too long for regular testing
-    spline = SplineCV(dampings=[None], mindists=[1e-5, 1e-3]).fit(coords, data.scalars)
+    spline = SplineCV(
+        dampings=[None],
+        mindists=[1e-5, 1e-3],
+        cv=ShuffleSplit(n_splits=2, random_state=0),
+    ).fit(coords, data.scalars)
     # The interpolation should be perfect on top of the data points
     npt.assert_allclose(spline.predict(coords), data.scalars, rtol=1e-5)
     npt.assert_allclose(spline.score(coords, data.scalars), 1)

--- a/verde/tests/utils.py
+++ b/verde/tests/utils.py
@@ -14,3 +14,15 @@ def requires_numba(function):
         numba = None
     mark = pytest.mark.skipif(numba is None, reason="requires numba")
     return mark(function)
+
+
+def requires_dask(function):
+    """
+    Skip the decorated test if dask.distributed is not installed.
+    """
+    try:
+        import dask.distributed
+    except ImportError:
+        dask = None
+    mark = pytest.mark.skipif(dask is None, reason="requires dask")
+    return mark(function)


### PR DESCRIPTION
The `SplineCV` class perfoms grid search cross-validation to auto-tune a `Spline`.
It uses `cross_val_score` to cross-validate and can be configured to run in parallel
with a `dask.distributed.Client` and take different scikit-learn splitters besides
`KFold`. Tested on the checkerboard function and add a gallery example using the
Texas temperature data.

<!-- Please describe changes proposed and WHY you made them. If unsure, open an issue first to discuss the idea. -->

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.