### PR TITLE
Split model selection and evaluation tutorials 

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,6 +33,7 @@
     tutorials/decimation.rst
     tutorials/projections.rst
     tutorials/chain.rst
+    tutorials/model_evaluation.rst
     tutorials/model_selection.rst
     tutorials/weights.rst
     tutorials/vectors.rst

--- a/tutorials/model_evaluation.py
+++ b/tutorials/model_evaluation.py
@@ -177,7 +177,9 @@ from sklearn.model_selection import ShuffleSplit
 
 shuffle = ShuffleSplit(n_splits=10, test_size=0.3, random_state=0)
 
-scores = vd.cross_val_score(vd.Spline(), proj_coords, data.air_temperature_c, cv=shuffle)
+scores = vd.cross_val_score(
+    vd.Spline(), proj_coords, data.air_temperature_c, cv=shuffle
+)
 print("shuffle scores:", scores)
 print("Mean score:", np.mean(scores))
 

--- a/tutorials/model_evaluation.py
+++ b/tutorials/model_evaluation.py
@@ -1,0 +1,188 @@
+"""
+.. _model_evaluation:
+
+Evaluating Performance
+======================
+
+The Green's functions based interpolations in Verde are all linear regressions under the
+hood. This means that we can use some of the same tactics from
+:mod:`sklearn.model_selection` to evaluate our interpolator's performance. Once we have
+a quantified measure of the quality of a given fitted gridder, we can use it to tune the
+gridder's parameters, like ``damping`` for a :class:`~verde.Spline` (see
+:ref:`model_selection`).
+
+Verde provides adaptations of common scikit-learn tools to work better with spatial
+data. Let's use these tools to evaluate the performance of a :class:`~verde.Spline` on
+our sample air temperature data.
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+import cartopy.crs as ccrs
+import pyproj
+import verde as vd
+
+data = vd.datasets.fetch_texas_wind()
+
+# Use Mercator projection because Spline is a Cartesian gridder
+projection = pyproj.Proj(proj="merc", lat_ts=data.latitude.mean())
+proj_coords = projection(data.longitude.values, data.latitude.values)
+
+region = vd.get_region((data.longitude, data.latitude))
+# For this data, we'll generate a grid with 15 arc-minute spacing
+spacing = 15 / 60
+
+########################################################################################
+# Splitting the data
+# ------------------
+#
+# We can't evaluate a gridder on the data that went into fitting it. The true test of a
+# model is if it can correctly predict data that it hasn't seen before. scikit-learn has
+# the :func:`sklearn.model_selection.train_test_split` function to separate a dataset
+# into two parts: one for fitting the model (called *training* data) and a separate one
+# for evaluating the model (called *testing* data). Using it with spatial data would
+# involve some tedious array conversions so Verde implements
+# :func:`verde.train_test_split` which does the same thing but takes coordinates and
+# data arrays instead.
+#
+# The split is done randomly so we specify a seed for the random number generator to
+# guarantee that we'll get the same result every time we run this example. You probably
+# don't want to do that for real data. We'll keep 30% of the data to use for testing
+# (``test_size=0.3``).
+
+train, test = vd.train_test_split(
+    proj_coords, data.air_temperature_c, test_size=0.3, random_state=0
+)
+
+########################################################################################
+# The returned ``train`` and ``test`` variables are tuples containing coordinates, data,
+# and (optionally) weights arrays. Since we're not using weights, the third element of
+# the tuple will be ``None``:
+print(train)
+
+
+########################################################################################
+#
+print(test)
+
+########################################################################################
+# Let's plot these two datasets with different colors:
+
+plt.figure(figsize=(8, 6))
+ax = plt.axes()
+ax.set_title("Air temperature measurements for Texas")
+ax.plot(train[0][0], train[0][1], ".r", label="train")
+ax.plot(test[0][0], test[0][1], ".b", label="test")
+ax.legend()
+ax.set_aspect("equal")
+plt.tight_layout()
+plt.show()
+
+########################################################################################
+# We can pass the training dataset to the :meth:`~verde.base.BaseGridder.fit` method of
+# most gridders using Python's argument expansion using the ``*`` symbol.
+
+spline = vd.Spline()
+spline.fit(*train)
+
+########################################################################################
+# Let's plot the gridded result to see what it looks like. First, we'll create a
+# geographic grid:
+grid = spline.grid(
+    region=region,
+    spacing=spacing,
+    projection=projection,
+    dims=["latitude", "longitude"],
+    data_names=["temperature"],
+)
+print(grid)
+
+########################################################################################
+# Then, we'll mask out grid points that are too far from any given data point and plot
+# the grid:
+mask = vd.distance_mask(
+    (data.longitude, data.latitude),
+    maxdist=3 * spacing * 111e3,
+    coordinates=vd.grid_coordinates(region, spacing=spacing),
+    projection=projection,
+)
+grid = grid.where(mask)
+
+plt.figure(figsize=(8, 6))
+ax = plt.axes(projection=ccrs.Mercator())
+ax.set_title("Gridded temperature")
+pc = grid.temperature.plot.pcolormesh(
+    ax=ax,
+    cmap="plasma",
+    transform=ccrs.PlateCarree(),
+    add_colorbar=False,
+    add_labels=False,
+)
+plt.colorbar(pc).set_label("C")
+ax.plot(data.longitude, data.latitude, ".k", markersize=1, transform=ccrs.PlateCarree())
+vd.datasets.setup_texas_wind_map(ax)
+plt.tight_layout()
+plt.show()
+
+########################################################################################
+# Scoring
+# --------
+#
+# Gridders in Verde implement the :meth:`~verde.base.BaseGridder.score` method that
+# calculates the `R² coefficient of determination
+# <https://en.wikipedia.org/wiki/Coefficient_of_determination>`__
+# for a given comparison dataset (``test`` in our case). The R² score is at most 1,
+# meaning a perfect prediction, but has no lower bound.
+
+score = spline.score(*test)
+print("R² score:", score)
+
+########################################################################################
+# That's a good score meaning that our gridder is able to accurately predict data that
+# wasn't used in the gridding algorithm.
+#
+# .. caution::
+#
+#     Once caveat for this score is that it is highly dependent on the particular split
+#     that we made. Changing the random number generator seed in
+#     :func:`verde.train_test_split` will result in a different score.
+
+# Use 1 as a seed instead of 0
+train_other, test_other = vd.train_test_split(
+    proj_coords, data.air_temperature_c, test_size=0.3, random_state=1
+)
+
+print("R² score with seed 1:", vd.Spline().fit(*train_other).score(*test_other))
+
+########################################################################################
+# Cross-validation
+# ----------------
+#
+# A more robust way of scoring the gridders is to use function
+# :func:`verde.cross_val_score`, which (by default) uses a `k-fold cross-validation
+# <https://en.wikipedia.org/wiki/Cross-validation_(statistics)#k-fold_cross-validation>`__
+# by default. It will split the data *k* times and return the score on each *fold*. We
+# can then take a mean of these scores.
+
+scores = vd.cross_val_score(vd.Spline(), proj_coords, data.air_temperature_c)
+print("k-fold scores:", scores)
+print("Mean score:", np.mean(scores))
+
+########################################################################################
+# You can also use most cross-validation splitter classes from
+# :mod:`sklearn.model_selection` by specifying the ``cv`` argument. For example, if we
+# want to shuffle then split the data *n* times
+# (:class:`sklearn.model_selection.ShuffleSplit`):
+
+from sklearn.model_selection import ShuffleSplit
+
+shuffle = ShuffleSplit(n_splits=10, test_size=0.3, random_state=0)
+
+scores = vd.cross_val_score(vd.Spline(), proj_coords, data.air_temperature_c, cv=shuffle)
+print("shuffle scores:", scores)
+print("Mean score:", np.mean(scores))
+
+########################################################################################
+# **That is not a very good score** so clearly the default arguments for
+# :class:`~verde.Spline` aren't suitable for this dataset. We could try different
+# combinations manually until we get a good score. A better way is to do this
+# automatically. In :ref:`model_selection` we'll go over how to do that.

--- a/tutorials/model_selection.py
+++ b/tutorials/model_selection.py
@@ -4,15 +4,12 @@
 Model Selection
 ===============
 
-The Green's functions based interpolations in Verde are all linear regressions under the
-hood. This means that we can use some of the same tactics from
-:mod:`sklearn.model_selection` to evaluate our interpolator's performance. Once we have
-a quantified measure of the quality of a given fitted gridder, we can use it to tune the
-gridder's parameters, like ``damping`` for a :class:`~verde.Spline`.
+In :ref:`model_evaluation`, we saw how to check the performance of an interpolator using
+cross-validation. We found that the default parameters for :class:`verde.Spline` are not
+good for predicting our sample air temperature data. Now, let's see how we can tune the
+:class:`~verde.Spline` to improve the cross-validation performance.
 
-Verde provides adaptations of common scikit-learn tools to work better with spatial
-data. Let's use these tools to evaluate and tune a :class:`~verde.Spline` to grid our
-sample air temperature data.
+Once again, we'll start by importing the required packages and loading our sample data.
 """
 import numpy as np
 import matplotlib.pyplot as plt
@@ -32,123 +29,16 @@ region = vd.get_region((data.longitude, data.latitude))
 spacing = 15 / 60
 
 ########################################################################################
-# Splitting the data
-# ------------------
-#
-# We can't evaluate a gridder on the data that went into fitting it. The true test of a
-# model is if it can correctly predict data that it hasn't seen before. scikit-learn has
-# the :func:`sklearn.model_selection.train_test_split` function to separate a dataset
-# into two parts: one for fitting the model (called *training* data) and a separate one
-# for evaluating the model (called *testing* data). Using it with spatial data would
-# involve some tedious array conversions so Verde implements
-# :func:`verde.train_test_split` which does the same thing but takes coordinates and
-# data arrays instead.
-#
-# The split is done randomly so we specify a seed for the random number generator to
-# guarantee that we'll get the same result every time we run this example. You probably
-# don't want to do that for real data. We'll keep 30% of the data to use for testing.
+# Before we begin tuning, let's reiterate what the results were with the default
+# parameters.
 
-train, test = vd.train_test_split(
-    proj_coords, data.air_temperature_c, test_size=0.3, random_state=0
+spline_default = vd.Spline()
+score_default = np.mean(
+    vd.cross_val_score(spline_default, proj_coords, data.air_temperature_c)
 )
-print(train)
-print(test)
+spline_default.fit(proj_coords, data.air_temperature_c)
+print("R² with defaults:", score_default)
 
-plt.figure(figsize=(8, 6))
-ax = plt.axes()
-ax.set_title("Air temperature measurements for Texas")
-ax.plot(train[0][0], train[0][1], ".r", label="train")
-ax.plot(test[0][0], test[0][1], ".b", label="test")
-ax.legend()
-ax.set_aspect("equal")
-plt.tight_layout()
-plt.show()
-
-########################################################################################
-# The returned ``train`` and ``test`` arguments are each tuples with the coordinates (in
-# a tuple) and a data array. They are in a format that can be easily passed to the
-# :meth:`~verde.base.BaseGridder.fit` method of most gridders using Python's argument
-# expansion using the ``*`` symbol.
-
-spline = vd.Spline()
-spline.fit(*train)
-
-########################################################################################
-# Let's plot the gridded result to see what it looks like. We'll mask out grid points
-# that are too far from any given data point.
-mask = vd.distance_mask(
-    (data.longitude, data.latitude),
-    maxdist=3 * spacing * 111e3,
-    coordinates=vd.grid_coordinates(region, spacing=spacing),
-    projection=projection,
-)
-grid = spline.grid(
-    region=region,
-    spacing=spacing,
-    projection=projection,
-    dims=["latitude", "longitude"],
-    data_names=["temperature"],
-).where(mask)
-
-plt.figure(figsize=(8, 6))
-ax = plt.axes(projection=ccrs.Mercator())
-ax.set_title("Gridded temperature")
-pc = grid.temperature.plot.pcolormesh(
-    ax=ax,
-    cmap="plasma",
-    transform=ccrs.PlateCarree(),
-    add_colorbar=False,
-    add_labels=False,
-)
-plt.colorbar(pc).set_label("C")
-ax.plot(data.longitude, data.latitude, ".k", markersize=1, transform=ccrs.PlateCarree())
-vd.datasets.setup_texas_wind_map(ax)
-plt.tight_layout()
-plt.show()
-
-########################################################################################
-# Scoring
-# --------
-#
-# Gridders in Verde implement the :meth:`~verde.base.BaseGridder.score` method that
-# calculates the `R² coefficient of determination
-# <https://en.wikipedia.org/wiki/Coefficient_of_determination>`__
-# for a given comparison dataset (``test`` in our case). The R² score is at most 1,
-# meaning a perfect prediction, but has no lower bound.
-
-score = spline.score(*test)
-print("R² score:", score)
-
-########################################################################################
-# That's a good score meaning that our gridder is able to accurately predict data that
-# wasn't used in the gridding algorithm.
-#
-# Once caveat for this score is that it is highly dependent on the particular split that
-# we made. Changing the random number generator seed in :func:`verde.train_test_split`
-# will result in a different score.
-
-# Use 1 as a seed instead of 0
-train_other, test_other = vd.train_test_split(
-    proj_coords, data.air_temperature_c, test_size=0.3, random_state=1
-)
-print("R² score with seed 1:", spline.fit(*train_other).score(*test_other))
-
-########################################################################################
-# A more robust way of scoring the gridders is to use function
-# :func:`verde.cross_val_score`, which (by default) uses a `k-fold cross-validation
-# <https://en.wikipedia.org/wiki/Cross-validation_(statistics)#k-fold_cross-validation>`__.
-# It will split the data *k* times and return the score on each *fold*. We can then take
-# a mean of these scores.
-
-scores = vd.cross_val_score(spline, proj_coords, data.air_temperature_c)
-print("k-fold scores:", scores)
-print("Mean score:", np.mean(scores))
-
-########################################################################################
-# That is not a very good score so clearly the default arguments for
-# :class:`~verde.Spline` aren't suitable for this dataset. We could try different
-# combinations manually until we get a good score. A better way is to do this
-# automatically.
 
 ########################################################################################
 # Tuning
@@ -176,6 +66,7 @@ print("Combinations:", parameter_sets)
 ########################################################################################
 # Now we can loop over the combinations and collect the scores for each parameter set.
 
+spline = vd.Spline()
 scores = []
 for params in parameter_sets:
     spline.set_params(**params)
@@ -188,30 +79,77 @@ print(scores)
 
 best = np.argmax(scores)
 print("Best score:", scores[best])
+print("Score with defaults:", score_default)
 print("Best parameters:", parameter_sets[best])
 
 ########################################################################################
-# That is a big improvement over our previous score!
+# **That is a big improvement over our previous score!**
 #
-# We can now configure our spline with the best configuration and re-fit.
+# This type of tuning is important and should always be performed when using a new
+# gridder or a new dataset. However, the above implementation requires a lot of
+# coding. Fortunately, Verde provides convenience classes that perform the
+# cross-validation and tuning automatically when fitting a dataset.
 
-spline.set_params(**parameter_sets[best])
+
+########################################################################################
+# Cross-validated gridders
+# ------------------------
+#
+# The :class:`verde.SplineCV` class provides a cross-validated version of
+# :class:`verde.Spline`. It has almost the same interface but does all of the above
+# automatically when fitting a dataset. The only difference is that you must provide a
+# list of ``damping`` and ``mindist`` parameters to try instead of only a single value:
+
+spline = vd.SplineCV(
+    dampings=[None, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1],
+    mindists=[5e3, 10e3, 25e3, 50e3, 75e3, 100e3],
+)
 spline.fit(proj_coords, data.air_temperature_c)
 
 ########################################################################################
-# Finally, we can make a grid with the best configuration to see how it compares to our
-# previous result.
+# The estimated best damping and mindist, as well as the cross-validation scores, are
+# stored in class attributes:
 
-grid_best = spline.grid(
+print("Highest score:", spline.scores_.max())
+print("Best damping:", spline.damping_)
+print("Best mindist:", spline.mindist_)
+
+########################################################################################
+# Finally, we can make a grid with the best configuration to see how it compares to the
+# default result.
+
+grid = spline.grid(
     region=region,
     spacing=spacing,
     projection=projection,
     dims=["latitude", "longitude"],
     data_names=["temperature"],
-).where(mask)
+)
+print(grid)
+
+########################################################################################
+# Let's plot our grid side-by-side with one generated by the default spline:
+
+grid_default = spline_default.grid(
+    region=region,
+    spacing=spacing,
+    projection=projection,
+    dims=["latitude", "longitude"],
+    data_names=["temperature"],
+)
+
+mask = vd.distance_mask(
+    (data.longitude, data.latitude),
+    maxdist=3 * spacing * 111e3,
+    coordinates=vd.grid_coordinates(region, spacing=spacing),
+    projection=projection,
+)
+
+grid = grid.where(mask)
+grid_default = grid_default.where(mask)
 
 plt.figure(figsize=(14, 8))
-for i, title, grd in zip(range(2), ["Defaults", "Tuned"], [grid, grid_best]):
+for i, title, grd in zip(range(2), ["Defaults", "Tuned"], [grid_default, grid]):
     ax = plt.subplot(1, 2, i + 1, projection=ccrs.Mercator())
     ax.set_title(title)
     pc = grd.temperature.plot.pcolormesh(
@@ -232,6 +170,6 @@ plt.tight_layout()
 plt.show()
 
 ########################################################################################
-# Notice that, for sparse data like these, smoother models tend to be better predictors.
-# This is a sign that you should probably not trust many of the short wavelength
-# features that we get from the defaults.
+# Notice that, for sparse data like these, **smoother models tend to be better
+# predictors**. This is a sign that you should probably not trust many of the short
+# wavelength features that we get from the defaults.


### PR DESCRIPTION
The previous model selection tutorial covered both scoring and automatic
tuning. Separate into two tutorials "Evaluating Performance" and "Model
Selection" so they are both shorter.
Include a section in "Model Selection" about the new `SplineCV` class
from #185.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.