### PR TITLE
Move the DummyClient to the verde/utils module

### DIFF
--- a/verde/model_selection.py
+++ b/verde/model_selection.py
@@ -8,28 +8,7 @@ import numpy as np
 from sklearn.model_selection import KFold, ShuffleSplit
 
 from .base import check_fit_input
-
-
-class DummyClient:  # pylint: disable=no-self-use,too-few-public-methods
-    """
-    Dummy client to mimic a dask.distributed.Client for immediate local
-    execution.
-
-    >>> client = DummyClient()
-    >>> client.submit(sum, (1, 2, 3))
-    6
-    >>> print(client.scatter("bla"))
-    bla
-
-    """
-
-    def submit(self, function, *args, **kwargs):
-        "Execute function with the given arguments and return its output"
-        return function(*args, **kwargs)
-
-    def scatter(self, value):
-        "Does nothing but return the input"
-        return value
+from .utils import DummyClient
 
 
 def train_test_split(coordinates, data, weights=None, **kwargs):

--- a/verde/spline.py
+++ b/verde/spline.py
@@ -9,8 +9,8 @@ from sklearn.utils.validation import check_is_fitted
 
 from .base import n_1d_arrays, BaseGridder, check_fit_input, least_squares
 from .coordinates import get_region
-from .utils import parse_engine
-from .model_selection import DummyClient, cross_val_score
+from .utils import DummyClient, parse_engine
+from .model_selection import cross_val_score
 
 try:
     import numba

--- a/verde/utils.py
+++ b/verde/utils.py
@@ -15,6 +15,28 @@ except ImportError:
 from .base.utils import check_data, n_1d_arrays
 
 
+class DummyClient:  # pylint: disable=no-self-use,too-few-public-methods
+    """
+    Dummy client to mimic a dask.distributed.Client for immediate local
+    execution.
+
+    >>> client = DummyClient()
+    >>> client.submit(sum, (1, 2, 3))
+    6
+    >>> print(client.scatter("bla"))
+    bla
+
+    """
+
+    def submit(self, function, *args, **kwargs):
+        "Execute function with the given arguments and return its output"
+        return function(*args, **kwargs)
+
+    def scatter(self, value):
+        "Does nothing but return the input"
+        return value
+
+
 def parse_engine(engine):
     """
     Choose the best engine available and check if it's valid.


### PR DESCRIPTION
This was in verde/model_selection for some reason. It should be in utils
instead and not public.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.