### PR TITLE
Fix breaking Spline test due to extra warnings

### DIFF
--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -42,6 +42,8 @@ class BaseGridder(BaseEstimator):
 
     >>> import verde as vd
     >>> import numpy as np
+    >>> import xarray as xr
+    >>> import pandas as pd
     >>> from sklearn.utils.validation import check_is_fitted
     >>> class MeanGridder(vd.base.BaseGridder):
     ...     "Gridder that always produces the mean of all data values"
@@ -71,14 +73,14 @@ class BaseGridder(BaseEstimator):
     MeanGridder(multiplier=1)
     >>> # Interpolate on a regular grid
     >>> grid = grd.grid(region=(0, 5, -10, -8), shape=(30, 20))
-    >>> type(grid)
-    <class 'xarray.core.dataset.Dataset'>
+    >>> isinstance(grid, xr.Dataset)
+    True
     >>> np.allclose(grid.scalars, -32.2182)
     True
     >>> # Interpolate along a profile
     >>> profile = grd.profile(point1=(0, -10), point2=(5, -8), size=10)
-    >>> type(profile)
-    <class 'pandas.core.frame.DataFrame'>
+    >>> isinstance(profile, pd.DataFrame)
+    True
     >>> print(', '.join(['{:.2f}'.format(i) for i in profile.distance]))
     0.00, 0.60, 1.20, 1.80, 2.39, 2.99, 3.59, 4.19, 4.79, 5.39
     >>> print(', '.join(['{:.1f}'.format(i) for i in profile.scalars]))

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -42,8 +42,6 @@ class BaseGridder(BaseEstimator):
 
     >>> import verde as vd
     >>> import numpy as np
-    >>> import xarray as xr
-    >>> import pandas as pd
     >>> from sklearn.utils.validation import check_is_fitted
     >>> class MeanGridder(vd.base.BaseGridder):
     ...     "Gridder that always produces the mean of all data values"
@@ -73,14 +71,10 @@ class BaseGridder(BaseEstimator):
     MeanGridder(multiplier=1)
     >>> # Interpolate on a regular grid
     >>> grid = grd.grid(region=(0, 5, -10, -8), shape=(30, 20))
-    >>> isinstance(grid, xr.Dataset)
-    True
     >>> np.allclose(grid.scalars, -32.2182)
     True
     >>> # Interpolate along a profile
     >>> profile = grd.profile(point1=(0, -10), point2=(5, -8), size=10)
-    >>> isinstance(profile, pd.DataFrame)
-    True
     >>> print(', '.join(['{:.2f}'.format(i) for i in profile.distance]))
     0.00, 0.60, 1.20, 1.80, 2.39, 2.99, 3.59, 4.19, 4.79, 5.39
     >>> print(', '.join(['{:.1f}'.format(i) for i in profile.scalars]))

--- a/verde/datasets/synthetic.py
+++ b/verde/datasets/synthetic.py
@@ -40,14 +40,13 @@ class CheckerBoard(BaseGridder):
 
     Examples
     --------
+
     >>> synth = CheckerBoard()
     >>> # Default values for the wavelengths are selected automatically
     >>> print(synth.w_east_, synth.w_north_)
     2500.0 2500.0
     >>> # Checkerboard.grid produces an xarray.Dataset with data on a regular grid
     >>> grid = synth.grid(shape=(11, 6))
-    >>> type(grid)
-    <class 'xarray.core.dataset.Dataset'>
     >>> # scatter and profile generate pandas.DataFrame objects
     >>> table = synth.scatter()
     >>> print(sorted(table.columns))

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -170,9 +170,8 @@ def test_spline_warns_weights():
     msg = "Weights might have no effect if no regularization is used"
     with warnings.catch_warnings(record=True) as warn:
         grd.fit((data.easting, data.northing), data.scalars, weights=weights)
-        assert len(warn) == 1
-        assert issubclass(warn[-1].category, UserWarning)
-        assert str(warn[-1].message).split(".")[0] == msg
+        assert len(warn) >= 1
+        assert any(str(w.message).split(".")[0] == msg for w in warn)
 
 
 def test_spline_warns_underdetermined():
@@ -181,9 +180,8 @@ def test_spline_warns_underdetermined():
     grd = Spline(force_coords=(np.arange(60), np.arange(60)))
     with warnings.catch_warnings(record=True) as warn:
         grd.fit((data.easting, data.northing), data.scalars)
-        assert len(warn) == 1
-        assert issubclass(warn[-1].category, UserWarning)
-        assert str(warn[-1].message).startswith("Under-determined problem")
+        assert len(warn) >= 1
+        assert any(str(w.message).startswith("Under-determined problem") for w in warn)
 
 
 @requires_numba


### PR DESCRIPTION
Some tests rely on checking if the code gives a warning. The test was
checking if the number of warnings is 1 and comparing the error message.
This breaks if any of our dependencies introduce warnings.
Fix by checking if >=1 warning and if any have the right message.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.