### PR TITLE
Update CI scripts and fix linting errors

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
     displayName: Add conda to PATH
 
   # Get the Fatiando CI scripts
-  - bash: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+  - bash: git clone --branch=1.2.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
   # Setup dependencies and build a conda environment
@@ -100,8 +100,14 @@ jobs:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: Add conda to PATH
 
+  # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation
+  # directory We need to take ownership if we want to update conda or install packages
+  # globally
+  - bash: sudo chown -R $USER $CONDA
+    displayName: Take ownership of conda installation
+
   # Get the Fatiando CI scripts
-  - bash: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+  - bash: git clone --branch=1.2.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
   # Setup dependencies and build a conda environment
@@ -193,7 +199,7 @@ jobs:
     displayName: Add conda to PATH
 
   # Get the Fatiando CI scripts
-  - script: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+  - script: git clone --branch=1.2.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts
 
   # Setup dependencies and build a conda environment

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
     - mkdir -p $HOME/.verde/data/master
     - cp -r data/* $HOME/.verde/data/master
     # Get the Fatiando CI scripts
-    - git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
+    - git clone --branch=1.2.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     # Download and install miniconda and setup dependencies
     # Need to source the script to set the PATH variable globaly
     - source continuous-integration/travis/setup-miniconda.sh

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring,import-outside-toplevel
 # Import functions/classes to make the public API
 from . import datasets
 from . import version

--- a/verde/datasets/sample_data.py
+++ b/verde/datasets/sample_data.py
@@ -7,6 +7,13 @@ import numpy as np
 import pandas as pd
 import pooch
 
+try:
+    import cartopy.feature as cfeature
+    import cartopy.crs as ccrs
+    from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
+except ImportError:
+    pass
+
 from ..version import full_version
 
 
@@ -26,8 +33,6 @@ def _setup_map(
     """
     Setup a Cartopy map with land and ocean features and proper tick labels.
     """
-    import cartopy.feature as cfeature
-    from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
 
     if land is not None:
         ax.add_feature(cfeature.LAND, facecolor=land)
@@ -93,8 +98,6 @@ def setup_baja_bathymetry_map(
     fetch_baja_bathymetry: Sample bathymetry data from Baja California.
 
     """
-    import cartopy.crs as ccrs
-
     _setup_map(
         ax,
         xticks=np.arange(-114, -105, 2),
@@ -167,8 +170,6 @@ def setup_rio_magnetic_map(ax, region=(-42.6, -42, -22.5, -22)):
     fetch_rio_magnetic: Sample magnetic anomaly data from Rio de Janeiro, Brazil.
 
     """
-    import cartopy.crs as ccrs
-
     _setup_map(
         ax,
         xticks=np.arange(-42.5, -42, 0.1),
@@ -237,8 +238,6 @@ def setup_california_gps_map(
     fetch_california_gps: Sample GPS velocity data from California.
 
     """
-    import cartopy.crs as ccrs
-
     _setup_map(
         ax,
         xticks=np.arange(-124, -115, 4),
@@ -301,7 +300,6 @@ def setup_texas_wind_map(
     fetch_texas_wind: Sample wind speed and air temperature data for Texas.
 
     """
-    import cartopy.crs as ccrs
 
     _setup_map(
         ax,

--- a/verde/tests/test_utils.py
+++ b/verde/tests/test_utils.py
@@ -1,7 +1,6 @@
 """
 Test the utility functions.
 """
-import sys
 from unittest import mock
 
 import numpy as np
@@ -11,15 +10,16 @@ import pytest
 
 from ..coordinates import grid_coordinates
 from ..utils import parse_engine, dummy_jit, kdtree
+from .. import utils
 
 
 def test_parse_engine():
     "Check that it works for common input"
     assert parse_engine("numba") == "numba"
     assert parse_engine("numpy") == "numpy"
-    with mock.patch.dict(sys.modules, {"numba": None}):
+    with mock.patch.object(utils, "numba", None):
         assert parse_engine("auto") == "numpy"
-    with mock.patch.dict(sys.modules, {"numba": mock.MagicMock()}):
+    with mock.patch.object(utils, "numba", mock.MagicMock()):
         assert parse_engine("auto") == "numba"
 
 

--- a/verde/tests/utils.py
+++ b/verde/tests/utils.py
@@ -3,15 +3,21 @@ Testing utilities.
 """
 import pytest
 
+try:
+    import numba
+except ImportError:
+    numba = None
+
+try:
+    from dask import distributed
+except ImportError:
+    distributed = None
+
 
 def requires_numba(function):
     """
     Skip the decorated test if numba is not installed.
     """
-    try:
-        import numba
-    except ImportError:
-        numba = None
     mark = pytest.mark.skipif(numba is None, reason="requires numba")
     return mark(function)
 
@@ -20,9 +26,5 @@ def requires_dask(function):
     """
     Skip the decorated test if dask.distributed is not installed.
     """
-    try:
-        import dask.distributed
-    except ImportError:
-        dask = None
-    mark = pytest.mark.skipif(dask is None, reason="requires dask")
+    mark = pytest.mark.skipif(distributed is None, reason="requires dask")
     return mark(function)

--- a/verde/utils.py
+++ b/verde/utils.py
@@ -12,6 +12,11 @@ try:
 except ImportError:
     pyKDTree = None
 
+try:
+    import numba
+except ImportError:
+    numba = None
+
 from .base.utils import check_data, n_1d_arrays
 
 
@@ -56,12 +61,9 @@ def parse_engine(engine):
     if engine not in engines:
         raise ValueError("Invalid engine '{}'. Must be in {}.".format(engine, engines))
     if engine == "auto":
-        try:
-            import numba  # pylint: disable=unused-variable,unused-import
-
-            return "numba"
-        except ImportError:
+        if numba is None:
             return "numpy"
+        return "numba"
     return engine
 
 


### PR DESCRIPTION
Pylint 2.4.2 generates some new error reports, mostly due to imports not
being at the top. Fix these by moving most imports to top.
Update CI scripts to 1.2.0 to fix failing TravisCI builds.
Take control of the conda path on Mac Azure builds to avoid conda
errors.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
