### PR TITLE
Update contact information to point to Slack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 
 `Documentation <http://www.fatiando.org/verde>`__ |
 `Documentation (dev version) <http://www.fatiando.org/verde/dev>`__ |
-`Contact <https://gitter.im/fatiando/fatiando>`__ |
+`Contact <http://contact.fatiando.org>`__ |
 Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 
 
@@ -25,9 +25,6 @@ Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 .. image:: https://img.shields.io/pypi/pyversions/verde.svg?style=flat-square
     :alt: Compatible Python versions.
     :target: https://pypi.python.org/pypi/verde
-.. image:: https://img.shields.io/gitter/room/fatiando/fatiando.svg?style=flat-square
-    :alt: Chat room on Gitter
-    :target: https://gitter.im/fatiando/fatiando
 .. image:: https://img.shields.io/badge/doi-10.21105%2Fjoss.00957-blue.svg?style=flat-square
     :alt: Digital Object Identifier for the JOSS paper
     :target: https://doi.org/10.21105/joss.00957
@@ -88,7 +85,7 @@ Contacting us
   Feel free to `open an issue
   <https://github.com/fatiando/verde/issues/new>`__ or comment
   on any open issue or pull request.
-* We have `chat room on Gitter <https://gitter.im/fatiando/fatiando>`__
+* We have `chat room on Slack <http://contact.fatiando.org>`__
   where you can ask questions and leave comments.
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -114,7 +114,7 @@ html_context = {
         ('<i class="fa fa-external-link-square fa-fw"></i> Fatiando a Terra', 'https://www.fatiando.org'),
         ('<i class="fa fa-users fa-fw"></i> Contributing', 'https://github.com/fatiando/verde/blob/master/CONTRIBUTING.md'),
         ('<i class="fa fa-gavel fa-fw"></i> Code of Conduct', 'https://github.com/fatiando/verde/blob/master/CODE_OF_CONDUCT.md'),
-        ('<i class="fa fa-comment fa-fw"></i> Contact', 'https://gitter.im/fatiando/fatiando'),
+        ('<i class="fa fa-comment fa-fw"></i> Contact', 'http://contact.fatiando.org'),
         ('<i class="fa fa-github fa-fw"></i> Source Code', 'https://github.com/fatiando/verde'),
     ],
     # Custom variables to enable "Improve this page"" and "Download notebook"


### PR DESCRIPTION
Use out new domain forward contact.fatiando.org to send people towards
Slack. In the docs, this can also be stable and we can update (even for
older pages) as needed.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
