### PR TITLE
Revert the use of attributes in check_is_fitted

### DIFF
--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -54,16 +54,12 @@ class BaseGridder(BaseEstimator):
     ...         if self.multiplier <= 0:
     ...             raise ValueError('Invalid multiplier {}'
     ...                              .format(self.multiplier))
-    ...         # Use a trailing underscore on the mean so we could
-    ...         # know if the gridder is already fitted before predicting
     ...         self.mean_ = data.mean()*self.multiplier
     ...         # fit should return self so that we can chain operations
     ...         return self
     ...     def predict(self, coordinates):
-    ...         # We know the gridder has been fitted if it has the mean_
-    ...         # attribute (or if the gridder has any attribute with a
-    ...         # trailing underscore)
-    ...         check_is_fitted(self)
+    ...         # We know the gridder has been fitted if it has the mean
+    ...         check_is_fitted(self, ['mean_'])
     ...         return np.ones_like(coordinates[0])*self.mean_
     >>> # Try it on some synthetic data
     >>> synthetic = vd.datasets.CheckerBoard(region=(0, 5, -10, 8))

--- a/verde/chain.py
+++ b/verde/chain.py
@@ -118,7 +118,7 @@ class Chain(BaseGridder):
             The data values predicted on the given points.
 
         """
-        check_is_fitted(self)
+        check_is_fitted(self, ["region_"])
         result = None
         for _, step in self.steps:
             if hasattr(step, "predict"):

--- a/verde/scipygridder.py
+++ b/verde/scipygridder.py
@@ -131,6 +131,6 @@ class ScipyGridder(BaseGridder):
             The data values interpolated on the given points.
 
         """
-        check_is_fitted(self)
+        check_is_fitted(self, ["interpolator_"])
         easting, northing = coordinates[:2]
         return self.interpolator_((easting, northing))

--- a/verde/spline.py
+++ b/verde/spline.py
@@ -231,7 +231,7 @@ class SplineCV(BaseGridder):
             The data values evaluated on the given points.
 
         """
-        check_is_fitted(self)
+        check_is_fitted(self, ["_best"])
         return self._best.predict(coordinates)
 
 

--- a/verde/trend.py
+++ b/verde/trend.py
@@ -149,7 +149,7 @@ class Trend(BaseGridder):
             The trend values evaluated on the given points.
 
         """
-        check_is_fitted(self)
+        check_is_fitted(self, ["coef_"])
         easting, northing = n_1d_arrays(coordinates, 2)
         shape = np.broadcast(*coordinates[:2]).shape
         data = np.zeros(easting.size, dtype=easting.dtype)

--- a/verde/vector.py
+++ b/verde/vector.py
@@ -138,7 +138,7 @@ class Vector(BaseGridder):
             :meth:`~verde.Vector.fit`.
 
         """
-        check_is_fitted(self)
+        check_is_fitted(self, ["region_"])
         return tuple(comp.predict(coordinates) for comp in self.components)
 
 


### PR DESCRIPTION
Rollback the changes in #217 because scikit-learn reverted the deprecation of 
`attributes` in `check_is_fitted`. See scikit-learn/scikit-learn#15947