### PR TITLE
Expose the optimal spline in SplineCV

### DIFF
--- a/verde/spline.py
+++ b/verde/spline.py
@@ -90,6 +90,9 @@ class SplineCV(BaseGridder):
         The optimal value for the *mindist* parameter.
     damping_ : float
         The optimal value for the *damping* parameter.
+    spline_ : :class:`verde.Spline`
+        A fitted :class:`~verde.Spline` with the optimal configuration
+        parameters.
 
     See also
     --------
@@ -182,34 +185,34 @@ class SplineCV(BaseGridder):
             scores = [score.result() for score in scores]
         self.scores_ = np.mean(scores, axis=1)
         best = np.argmax(self.scores_)
-        self._best = Spline(**parameter_sets[best])
-        self._best.fit(coordinates, data, weights=weights)
+        self.spline_ = Spline(**parameter_sets[best])
+        self.spline_.fit(coordinates, data, weights=weights)
         return self
 
     @property
     def force_(self):
         "The estimated forces that fit the data."
-        return self._best.force_
+        return self.spline_.force_
 
     @property
     def region_(self):
         "The bounding region of the data used to fit the spline"
-        return self._best.region_
+        return self.spline_.region_
 
     @property
     def damping_(self):
         "The optimal damping parameter"
-        return self._best.damping
+        return self.spline_.damping
 
     @property
     def mindist_(self):
         "The optimal mindist parameter"
-        return self._best.mindist
+        return self.spline_.mindist
 
     @property
     def force_coords_(self):
         "The optimal force locations"
-        return self._best.force_coords_
+        return self.spline_.force_coords_
 
     def predict(self, coordinates):
         """
@@ -231,8 +234,8 @@ class SplineCV(BaseGridder):
             The data values evaluated on the given points.
 
         """
-        check_is_fitted(self, ["_best"])
-        return self._best.predict(coordinates)
+        check_is_fitted(self, ["spline_"])
+        return self.spline_.predict(coordinates)
 
 
 class Spline(BaseGridder):


### PR DESCRIPTION
SplineCV was keeping the best Spline instance in `SplineCV._best` which
goes against the scikit-learn standard of storing estimated parameters
in variables ending in `_`. Change that to `SplineCV.spline_` and add it
to the class attribute list.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
