### PR TITLE
Use pooch.os_cache and pkg_resources in datasets

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -77,7 +77,7 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov"
-    VERDE_DATA_DIR: "data_dir"
+    VERDE_DATA_DIR: "verde_data_cache"
 
   strategy:
     matrix:
@@ -179,7 +179,7 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov"
-    VERDE_DATA_DIR: "data_dir"
+    VERDE_DATA_DIR: "verde_data_cache"
 
   strategy:
     matrix:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -77,7 +77,7 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov"
-    VERDE_DATA_DIR: "$HOME/.verde/data/master"
+    VERDE_DATA_DIR: "$HOME/.verde/data"
 
   strategy:
     matrix:
@@ -128,8 +128,8 @@ jobs:
   # Copy the test data to the cache folder
   - bash: |
       set -x -e
-      mkdir -p $VERDE_DATA_DIR
-      cp -r data/* $VERDE_DATA_DIR
+      mkdir -p ${VERDE_DATA_DIR}/master
+      cp -r data/* ${VERDE_DATA_DIR}/master
     displayName: Copy test data to cache
 
   # Install the package
@@ -179,7 +179,7 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov"
-    VERDE_DATA_DIR: "~/.verde/data/master"
+    VERDE_DATA_DIR: "~/.verde/data"
 
   strategy:
     matrix:
@@ -224,8 +224,8 @@ jobs:
   # Copy the test data to the cache folder
   - bash: |
       set -x -e
-      mkdir -p $VERDE_DATA_DIR
-      cp -r data/* $VERDE_DATA_DIR
+      mkdir -p ${VERDE_DATA_DIR}/master
+      cp -r data/* ${VERDE_DATA_DIR}/master
     displayName: Copy test data to cache
 
   # Install the package that we want to test

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -77,7 +77,7 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov"
-    VERDE_DATA_DIR: "$HOME/.verde/data"
+    VERDE_DATA_DIR: "data_dir"
 
   strategy:
     matrix:
@@ -179,7 +179,7 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov"
-    VERDE_DATA_DIR: "~/.verde/data"
+    VERDE_DATA_DIR: "data_dir"
 
   strategy:
     matrix:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -77,7 +77,7 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov"
-    VERDE_DATA_DIR: "verde_data_cache"
+    VERDE_DATA_DIR: "$(Agent.TempDirectory)/.verde/data"
 
   strategy:
     matrix:
@@ -180,7 +180,7 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov"
-    VERDE_DATA_DIR: "verde_data_cache"
+    VERDE_DATA_DIR: "$(Agent.TempDirectory)/.verde/data"
 
   strategy:
     matrix:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -144,6 +144,7 @@ jobs:
   - bash: |
       set -x -e
       source activate testing
+      ls ${VERDE_DATA_DIR}/master
       make test
     displayName: Test
 
@@ -240,6 +241,7 @@ jobs:
   - bash: |
       set -x -e
       source activate testing
+      ls ${VERDE_DATA_DIR}/master
       make test
     displayName: Test
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -77,6 +77,7 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov"
+    VERDE_DATA_DIR: "$HOME/.verde/data/master"
 
   strategy:
     matrix:
@@ -127,8 +128,8 @@ jobs:
   # Copy the test data to the cache folder
   - bash: |
       set -x -e
-      mkdir -p $HOME/.verde/data/master
-      cp -r data/* $HOME/.verde/data/master
+      mkdir -p $VERDE_DATA_DIR
+      cp -r data/* $VERDE_DATA_DIR
     displayName: Copy test data to cache
 
   # Install the package
@@ -178,6 +179,7 @@ jobs:
     CONDA_REQUIREMENTS: requirements.txt
     CONDA_REQUIREMENTS_DEV: requirements-dev.txt
     CONDA_INSTALL_EXTRA: "codecov"
+    VERDE_DATA_DIR: "~/.verde/data/master"
 
   strategy:
     matrix:
@@ -222,8 +224,8 @@ jobs:
   # Copy the test data to the cache folder
   - bash: |
       set -x -e
-      mkdir -p ~/.verde/data/master
-      cp -r data/* ~/.verde/data/master
+      mkdir -p $VERDE_DATA_DIR
+      cp -r data/* $VERDE_DATA_DIR
     displayName: Copy test data to cache
 
   # Install the package that we want to test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
         # PyPI password for deploying releases (TWINE_PASSWORD)
         - secure: "Gvd2kH5bGIng7Wz3R4Md5d48qU0vYo0Sb4g7A1UAn8EOuWAcbkdSAq5yDiAp4pENeGceHQG0+jX+GQBZoSOMUpwAfhPkWG5HBIc+P/G+iTUyF2oELLCekcGgccPzwNgQt574FzM0PkC9L4hINNRjVtnFa+SIx72D2r1OdTvmk2+c4jXBZl52e4l5dU+Hjzwh22KNzAMtXDVuvr3NVdJZHA/ldTwEBUQfiLo2CGkgls6o8ZLixK0tCRGIFKlZko9WeBTzQYidloSo3EQx0eqiTz7qydm3UfCezA9UYPefGOtUaA/4ysqs8tgG8xrnx8NhhRqH9pfPAhgsCMwfmtibslNwH+C7gtbERT8lLY5NfU1xyDC4UxkjbwbzKQno/vPhiqEJ/uR458IdZbzUeWXlt+Rz+Dyj1lW7FqPLOl3Zpfgfv1swWqxjVwduV46c3nlgu9fEkAiEH2SzAtBlsQ2qwbJCZKXj+8Ps9FmaqvQ+SCOTAycgR9WnYoIIutpn0cs3k8zqqQyBq2zXJLkPHflVich8wKKaOsaFMCIKLWaOODCw5fLkfxck/QtlolGGFi3lh5W5p4Zxxr7KdL8f+UrkAb6gY9LStvqwe2rSG2olqc95+zozsMY/YHXTIG092WB3EmptwO9jL67D3AIVBKOdvcRYFetWMyY61ZmEK0s/43I="
         - TWINE_USERNAME=Leonardo.Uieda
-        - VERDE_DATA_DIR="$HOME/.verde/data/master"
+        - VERDE_DATA_DIR="$HOME/.verde/data"
         # The file with the listed requirements to be installed by conda
         - CONDA_REQUIREMENTS=requirements.txt
         - CONDA_REQUIREMENTS_DEV=requirements-dev.txt
@@ -66,8 +66,8 @@ matrix:
 # Setup the build environment
 before_install:
     # Copy sample data to the verde data dir to avoid downloading all the time
-    - mkdir -p $VERDE_DATA_DIR
-    - cp -r data/* $VERDE_DATA_DIR
+    - mkdir -p ${VERDE_DATA_DIR}/master
+    - cp -r data/* ${VERDE_DATA_DIR}/master
     # Get the Fatiando CI scripts
     - git clone --branch=1.2.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     # Download and install miniconda and setup dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
         # PyPI password for deploying releases (TWINE_PASSWORD)
         - secure: "Gvd2kH5bGIng7Wz3R4Md5d48qU0vYo0Sb4g7A1UAn8EOuWAcbkdSAq5yDiAp4pENeGceHQG0+jX+GQBZoSOMUpwAfhPkWG5HBIc+P/G+iTUyF2oELLCekcGgccPzwNgQt574FzM0PkC9L4hINNRjVtnFa+SIx72D2r1OdTvmk2+c4jXBZl52e4l5dU+Hjzwh22KNzAMtXDVuvr3NVdJZHA/ldTwEBUQfiLo2CGkgls6o8ZLixK0tCRGIFKlZko9WeBTzQYidloSo3EQx0eqiTz7qydm3UfCezA9UYPefGOtUaA/4ysqs8tgG8xrnx8NhhRqH9pfPAhgsCMwfmtibslNwH+C7gtbERT8lLY5NfU1xyDC4UxkjbwbzKQno/vPhiqEJ/uR458IdZbzUeWXlt+Rz+Dyj1lW7FqPLOl3Zpfgfv1swWqxjVwduV46c3nlgu9fEkAiEH2SzAtBlsQ2qwbJCZKXj+8Ps9FmaqvQ+SCOTAycgR9WnYoIIutpn0cs3k8zqqQyBq2zXJLkPHflVich8wKKaOsaFMCIKLWaOODCw5fLkfxck/QtlolGGFi3lh5W5p4Zxxr7KdL8f+UrkAb6gY9LStvqwe2rSG2olqc95+zozsMY/YHXTIG092WB3EmptwO9jL67D3AIVBKOdvcRYFetWMyY61ZmEK0s/43I="
         - TWINE_USERNAME=Leonardo.Uieda
+        - VERDE_DATA_DIR="$HOME/.verde/data/master"
         # The file with the listed requirements to be installed by conda
         - CONDA_REQUIREMENTS=requirements.txt
         - CONDA_REQUIREMENTS_DEV=requirements-dev.txt
@@ -65,8 +66,8 @@ matrix:
 # Setup the build environment
 before_install:
     # Copy sample data to the verde data dir to avoid downloading all the time
-    - mkdir -p $HOME/.verde/data/master
-    - cp -r data/* $HOME/.verde/data/master
+    - mkdir -p $VERDE_DATA_DIR
+    - cp -r data/* $VERDE_DATA_DIR
     # Get the Fatiando CI scripts
     - git clone --branch=1.2.0 --depth=1 https://github.com/fatiando/continuous-integration.git
     # Download and install miniconda and setup dependencies

--- a/data/examples/README.txt
+++ b/data/examples/README.txt
@@ -3,27 +3,23 @@
 Sample Data
 ===========
 
-Verde provides some sample data and ways of generating synthetic data through the
-:mod:`verde.datasets` module. The sample data are automatically downloaded from the `Github
-repository <https://github.com/fatiando/verde>`__ to a folder on your computer the first
-time you use them. After that, the data are loaded from this folder. The download is
-managed by the :mod:`pooch` package.
+Verde provides some sample data and ways of generating synthetic data through
+the :mod:`verde.datasets` module.
 
+Where are my data files?
+------------------------
 
-Where is my data?
------------------
+The sample data files are downloaded automatically by :mod:`pooch` the first
+time you load them. The files are saved to the default cache location on your
+operating system. The location varies depending on your system and
+configuration. We provide the :func:`verde.datasets.locate` function if you
+need to find the data storage location on your system.
 
-The data files are downloaded to a folder ``~/.verde/data/`` by default. This is the
-*base data directory*. :mod:`pooch` will create a separate folder in the base directory
-for each version of Verde. So for Verde 0.1, the base data dir is ``~/.verde/data/0.1``.
-If you're using the latest development version from Github, the version is ``master``.
-
-You can change the base data directory by setting the ``VERDE_DATA_DIR`` environment
-variable to a different path.
-
+You can change the base data directory by setting the ``VERDE_DATA_DIR``
+environment variable to the desired path.
 
 Available datasets
 ------------------
 
-These are the datasets currently available. Most also come with a function for setting
-up a Cartopy map to display the data.
+These are the datasets currently available. Most also come with a companion
+function for setting up a Cartopy map to display the data.

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -93,6 +93,7 @@ Datasets
 .. autosummary::
    :toctree: generated/
 
+    datasets.locate
     datasets.CheckerBoard
     datasets.fetch_baja_bathymetry
     datasets.setup_baja_bathymetry_map

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ scipy
 pandas
 xarray
 scikit-learn
-pooch
+pooch>=0.7.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,14 @@ PACKAGE_DATA = {
     "verde.datasets": ["registry.txt"],
     "verde.tests": ["data/*", "baseline/*"],
 }
-INSTALL_REQUIRES = ["numpy", "scipy", "pandas", "xarray", "scikit-learn", "pooch"]
+INSTALL_REQUIRES = [
+    "numpy",
+    "scipy",
+    "pandas",
+    "xarray",
+    "scikit-learn",
+    "pooch>=0.7.0",
+]
 PYTHON_REQUIRES = ">=3.6"
 
 if __name__ == "__main__":

--- a/verde/datasets/__init__.py
+++ b/verde/datasets/__init__.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring
 from .synthetic import CheckerBoard
 from .sample_data import (
+    locate,
     fetch_baja_bathymetry,
     setup_baja_bathymetry_map,
     fetch_rio_magnetic,

--- a/verde/datasets/sample_data.py
+++ b/verde/datasets/sample_data.py
@@ -1,7 +1,6 @@
 """
 Functions to load sample data
 """
-import os
 import warnings
 
 import pkg_resources

--- a/verde/datasets/sample_data.py
+++ b/verde/datasets/sample_data.py
@@ -21,14 +21,15 @@ from ..version import full_version
 # Otherwise, DeprecationWarning won't be shown, kind of defeating the purpose.
 warnings.simplefilter("default")
 
-POOCH = pooch.create(
+REGISTRY = pooch.create(
     path=pooch.os_cache("verde"),
     base_url="https://github.com/fatiando/verde/raw/{version}/data/",
     version=full_version,
     version_dev="master",
     env="VERDE_DATA_DIR",
 )
-POOCH.load_registry(pkg_resources.resource_stream("verde.datasets", "registry.txt"))
+with pkg_resources.resource_stream("verde.datasets", "registry.txt") as registry_file:
+    REGISTRY.load_registry(registry_file)
 
 
 def locate():
@@ -49,7 +50,7 @@ def locate():
         The local data storage location.
 
     """
-    return str(POOCH.abspath)
+    return str(REGISTRY.abspath)
 
 
 def _setup_map(
@@ -96,7 +97,7 @@ def fetch_baja_bathymetry():
     setup_baja_bathymetry_map: Utility function to help setup a Cartopy map.
 
     """
-    data_file = POOCH.fetch("baja-bathymetry.csv.xz")
+    data_file = REGISTRY.fetch("baja-bathymetry.csv.xz")
     data = pd.read_csv(data_file, compression="xz")
     return data
 
@@ -182,7 +183,7 @@ def fetch_rio_magnetic():
         "in Verde v2.0.0. Use a different dataset instead.",
         DeprecationWarning,
     )
-    data_file = POOCH.fetch("rio-magnetic.csv.xz")
+    data_file = REGISTRY.fetch("rio-magnetic.csv.xz")
     data = pd.read_csv(data_file, compression="xz")
     return data
 
@@ -261,7 +262,7 @@ def fetch_california_gps():
     setup_california_gps_map: Utility function to help setup a Cartopy map.
 
     """
-    data_file = POOCH.fetch("california-gps.csv.xz")
+    data_file = REGISTRY.fetch("california-gps.csv.xz")
     data = pd.read_csv(data_file, compression="xz")
     return data
 
@@ -322,7 +323,7 @@ def fetch_texas_wind():
     setup_texas_wind_map: Utility function to help setup a Cartopy map.
 
     """
-    data_file = POOCH.fetch("texas-wind.csv")
+    data_file = REGISTRY.fetch("texas-wind.csv")
     data = pd.read_csv(data_file)
     return data
 

--- a/verde/datasets/sample_data.py
+++ b/verde/datasets/sample_data.py
@@ -4,6 +4,7 @@ Functions to load sample data
 import os
 import warnings
 
+import pkg_resources
 import numpy as np
 import pandas as pd
 import pooch
@@ -22,13 +23,34 @@ from ..version import full_version
 warnings.simplefilter("default")
 
 POOCH = pooch.create(
-    path=["~", ".verde", "data"],
+    path=pooch.os_cache("verde"),
     base_url="https://github.com/fatiando/verde/raw/{version}/data/",
     version=full_version,
     version_dev="master",
     env="VERDE_DATA_DIR",
 )
-POOCH.load_registry(os.path.join(os.path.dirname(__file__), "registry.txt"))
+POOCH.load_registry(pkg_resources.resource_stream("verde.datasets", "registry.txt"))
+
+
+def locate():
+    r"""
+    The absolute path to the sample data storage location on disk.
+
+    This is where the data are saved on your computer. The location is
+    dependent on the operating system. The folder locations are defined by the
+    ``appdirs``  package (see the `appdirs documentation
+    <https://github.com/ActiveState/appdirs>`__).
+
+    The location can be overwritten by the ``VERDE_DATA_DIR`` environment
+    variable to the desired destination.
+
+    Returns
+    -------
+    path : str
+        The local data storage location.
+
+    """
+    return str(POOCH.abspath)
 
 
 def _setup_map(

--- a/verde/tests/test_datasets.py
+++ b/verde/tests/test_datasets.py
@@ -1,12 +1,15 @@
 """
 Test data fetching routines.
 """
+import os
+
 import matplotlib.pyplot as plt
 import cartopy.crs as ccrs
 
 import pytest
 
 from ..datasets.sample_data import (
+    locate,
     fetch_baja_bathymetry,
     setup_baja_bathymetry_map,
     fetch_rio_magnetic,
@@ -16,6 +19,15 @@ from ..datasets.sample_data import (
     fetch_texas_wind,
     setup_texas_wind_map,
 )
+
+
+def test_datasets_locate():
+    "Make sure the data cache location has the right package name"
+    path = locate()
+    assert os.path.exists(path)
+    # This is the most we can check in a platform independent way without
+    # testing appdirs itself.
+    assert "verde" in path
 
 
 def test_fetch_texas_wind():


### PR DESCRIPTION
With Pooch 0.7.0, the recommended way of loading the registry file is
with `pkg_resources` (see fatiando/pooch#120). It's also better to use
the default cache location so users can more easily clean up unused
files. Because this is system specific, add the `verde.datasets.locate`
function to return the cache folder location.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
