### PR TITLE
Add affiliations and ORCIDs to AUTHORS file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,10 +1,11 @@
 # Project Authors
 
-This project was started by [Leonardo Uieda](http://www.leouieda.com/). The following
-people have made contributions to the project (in alphabetical order by last name) and
-are considered "The Verde Developers":
+This project was started by [Leonardo Uieda](http://www.leouieda.com/).
+
+The following people have made contributions to the project (in alphabetical
+order by last name) and are considered "The Verde Developers":
 
 * [David Hoese](https://github.com/djhoese)
 * [Jesse Pisel](https://github.com/jessepisel)
-* [Santiago R. Soler](https://github.com/santisoler)
-* [Leonardo Uieda](https://github.com/leouieda)
+* [Santiago Soler](https://github.com/santisoler) - Universidad Nacional de San Juan, Argentina (ORCID: 0000-0001-9202-5317)
+* [Leonardo Uieda](https://github.com/leouieda) - University of Liverpool, UK (ORCID: 0000-0001-6123-9515)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,7 +1,5 @@
 # Project Authors
 
-This project was started by [Leonardo Uieda](http://www.leouieda.com/).
-
 The following people have made contributions to the project (in alphabetical
 order by last name) and are considered "The Verde Developers":
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,7 +3,8 @@
 The following people have made contributions to the project (in alphabetical
 order by last name) and are considered "The Verde Developers":
 
-* [David Hoese](https://github.com/djhoese)
-* [Jesse Pisel](https://github.com/jessepisel)
-* [Santiago Soler](https://github.com/santisoler) - Universidad Nacional de San Juan, Argentina (ORCID: 0000-0001-9202-5317)
-* [Leonardo Uieda](https://github.com/leouieda) - University of Liverpool, UK (ORCID: 0000-0001-6123-9515)
+* [David Hoese](https://github.com/djhoese) - University of Wisconsin - Madison, USA (ORCID: [0000-0003-1167-7829](https://www.orcid.org/0000-0003-1167-7829))
+* [Lindsey Heagy](https://github.com/lheagy) - University of California Berkeley, Department of Statistics, USA (ORCID: [0000-0002-1551-5926](https://www.orcid.org/0000-0002-1551-5926))
+* [Jesse Pisel](https://github.com/jessepisel) - University of Texas at Austin, College of Natural Sciences, USA (ORCID: [0000-0002-7358-0590](https://www.orcid.org/0000-0002-7358-0590))
+* [Santiago Soler](https://github.com/santisoler) - Universidad Nacional de San Juan, Argentina (ORCID: [0000-0001-9202-5317](https://www.orcid.org/0000-0001-9202-5317))
+* [Leonardo Uieda](https://github.com/leouieda) - University of Liverpool, UK (ORCID: [0000-0001-6123-9515](https://www.orcid.org/0000-0001-6123-9515))


### PR DESCRIPTION
The authorship guidelines introduced in fatiando/contributing#13 specify that authors on Zenodo archives will be taken from the `AUTHORS.md` file and need to have full names, affiliation, and ORCIDs (optionally) included in that file. 

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and `verde/__init__.py`.
- [ ] Write detailed docstrings for all functions/classes/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
