### PR TITLE
Allow grid_to_table to take DataArrays

### DIFF
--- a/verde/utils.py
+++ b/verde/utils.py
@@ -226,8 +226,8 @@ def grid_to_table(grid):
     table : :class:`pandas.DataFrame`
         Table with coordinates and variable values for each point in the grid.
         Column names are taken from the grid. If *grid* is a
-        :class:`xarray.DataArray`, the column with data values will be called
-        ``"scalars"``.
+        :class:`xarray.DataArray` that doesn't have a ``name`` attribute
+        defined, the column with data values will be called ``"scalars"``.
 
     Examples
     --------
@@ -245,7 +245,7 @@ def grid_to_table(grid):
      [ 5  6  7  8  9]
      [10 11 12 13 14]
      [15 16 17 18 19]]
-    >>> # When converting DataArrays, the data column will be "scalars"
+    >>> # For DataArrays, the data column will be "scalars" by default
     >>> table = grid_to_table(temperature)
     >>> list(sorted(table.columns))
     ['easting', 'northing', 'scalars']
@@ -255,6 +255,11 @@ def grid_to_table(grid):
     [0 0 0 0 0 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3]
     >>> print(table.easting.values)
     [5 6 7 8 9 5 6 7 8 9 5 6 7 8 9 5 6 7 8 9]
+    >>> # If the DataArray defines a "name", we will use that instead
+    >>> temperature.name = "temperature_K"
+    >>> table = grid_to_table(temperature)
+    >>> list(sorted(table.columns))
+    ['easting', 'northing', 'temperature_K']
     >>> # Conversion of Datasets will preserve the data variable names
     >>> grid = xr.Dataset({"temperature": temperature})
     >>> table  = grid_to_table(grid)
@@ -293,7 +298,7 @@ def grid_to_table(grid):
         coordinate_names = list(grid[data_names[0]].dims)
     else:
         # It's a DataArray
-        data_names = ["scalars"]
+        data_names = [grid.name if grid.name is not None else "scalars"]
         data_arrays = [grid.values.ravel()]
         coordinate_names = list(grid.dims)
     north = grid.coords[coordinate_names[0]].values

--- a/verde/utils.py
+++ b/verde/utils.py
@@ -218,13 +218,16 @@ def grid_to_table(grid):
 
     Parameters
     ----------
-    grid : :class:`xarray.Dataset`
+    grid : :class:`xarray.Dataset` or :class:`xarray.DataArray`
         A 2D grid with one or more data variables.
 
     Returns
     -------
     table : :class:`pandas.DataFrame`
         Table with coordinates and variable values for each point in the grid.
+        Column names are taken from the grid. If *grid* is a
+        :class:`xarray.DataArray`, the column with data values will be called
+        ``"scalars"``.
 
     Examples
     --------
@@ -242,16 +245,27 @@ def grid_to_table(grid):
      [ 5  6  7  8  9]
      [10 11 12 13 14]
      [15 16 17 18 19]]
-    >>> grid = xr.Dataset({"temperature": temperature})
-    >>> table  = grid_to_table(grid)
+    >>> # When converting DataArrays, the data column will be "scalars"
+    >>> table = grid_to_table(temperature)
     >>> list(sorted(table.columns))
-    ['easting', 'northing', 'temperature']
+    ['easting', 'northing', 'scalars']
+    >>> print(table.scalars.values)
+    [ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19]
     >>> print(table.northing.values)
     [0 0 0 0 0 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3]
     >>> print(table.easting.values)
     [5 6 7 8 9 5 6 7 8 9 5 6 7 8 9 5 6 7 8 9]
+    >>> # Conversion of Datasets will preserve the data variable names
+    >>> grid = xr.Dataset({"temperature": temperature})
+    >>> table  = grid_to_table(grid)
+    >>> list(sorted(table.columns))
+    ['easting', 'northing', 'temperature']
     >>> print(table.temperature.values)
     [ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19]
+    >>> print(table.northing.values)
+    [0 0 0 0 0 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3]
+    >>> print(table.easting.values)
+    [5 6 7 8 9 5 6 7 8 9 5 6 7 8 9 5 6 7 8 9]
     >>> # Grids with multiple data variables will have more columns.
     >>> wind_speed = xr.DataArray(
     ...     np.arange(20, 40).reshape((4, 5)),
@@ -272,9 +286,16 @@ def grid_to_table(grid):
     [20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39]
 
     """
-    data_names = list(grid.data_vars.keys())
-    data_arrays = [grid[name].values.ravel() for name in data_names]
-    coordinate_names = list(grid[data_names[0]].dims)
+    if hasattr(grid, "data_vars"):
+        # It's a Dataset
+        data_names = list(grid.data_vars.keys())
+        data_arrays = [grid[name].values.ravel() for name in data_names]
+        coordinate_names = list(grid[data_names[0]].dims)
+    else:
+        # It's a DataArray
+        data_names = ["scalars"]
+        data_arrays = [grid.values.ravel()]
+        coordinate_names = list(grid.dims)
     north = grid.coords[coordinate_names[0]].values
     east = grid.coords[coordinate_names[1]].values
     # Need to flip the coordinates because the names are in northing and


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Previously would fail because we rely on getting the data variable names
from the Dataset. Need to check if it's a Dataset (has the `data_vars`
attribute) and set the data column name to differently if it's not.
The data column name will be `DataArray.name` or "scalars" (if it's None).

Fixes #225



**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
