### PR TITLE
Add function for rolling windows on irregular data

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -60,7 +60,7 @@ Coordinate Manipulation
     project_region
     inside
     block_split
-    rolling_split
+    rolling_window
 
 Utilities
 ---------

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -60,6 +60,7 @@ Coordinate Manipulation
     project_region
     inside
     block_split
+    rolling_split
 
 Utilities
 ---------

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -7,6 +7,7 @@ from .coordinates import (
     grid_coordinates,
     inside,
     block_split,
+    rolling_split,
     profile_coordinates,
     get_region,
     pad_region,

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -7,7 +7,7 @@ from .coordinates import (
     grid_coordinates,
     inside,
     block_split,
-    rolling_split,
+    rolling_window,
     profile_coordinates,
     get_region,
     pad_region,

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -799,8 +799,7 @@ def rolling_split(
     ----------
     coordinates : tuple of arrays
         Arrays with the coordinates of each data point. Should be in the
-        following order: (easting, northing, vertical, ...). Only easting and
-        northing will be used, all subsequent coordinates will be ignored.
+        following order: (easting, northing, vertical, ...).
     size : float
         The size of the windows. Units should match the units of *coordinates*.
     spacing : float, tuple = (s_north, s_east), or None
@@ -946,6 +945,7 @@ def rolling_split(
     centers = grid_coordinates(
         window_region, spacing=spacing, shape=shape, adjust=adjust
     )
+    step = centers[0][0]
     # pykdtree doesn't support query_ball_point yet and we need that
     tree = kdtree(coordinates, use_pykdtree=False)
     # Coordinates must be transposed because the kd-tree wants them as columns

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -948,6 +948,9 @@ def rolling_split(
     )
     # pykdtree doesn't support query_ball_point yet and we need that
     tree = kdtree(coordinates, use_pykdtree=False)
+    # Coordinates must be transposed because the kd-tree wants them as columns
+    # of a matrix
+    # Use p=inf (infinity norm) to get square windows instead of circular ones
     indices1d = tree.query_ball_point(
         np.transpose(n_1d_arrays(centers, 2)), r=size / 2, p=np.inf
     )

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -823,15 +823,14 @@ def rolling_window(
     Returns
     -------
     window_coordinates : tuple of arrays
-        (easting, northing) arrays with the coordinates of the center of each
-        window.
-    indices : list
-        Each element of the list corresponds to a window. Each contains the
-        indices of points falling inside the respective window. Use them to
-        index the coordinates for each window. The indices will depend on the
-        number of dimensions in the input coordinates. For example, if the
-        coordinates are 2D arrays, each window will contain indices for 2
-        dimensions (row, column).
+        Coordinate arrays for the center of each window.
+    indices : array
+        Each element of the array corresponds the indices of points falling
+        inside a window. The array will have the same shape as the
+        *window_coordinates*. Use the array elements to index the coordinates
+        for each window. The indices will depend on the number of dimensions in
+        the input coordinates. For example, if the coordinates are 2D arrays,
+        each window will contain indices for 2 dimensions (row, column).
 
     See also
     --------

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -954,7 +954,12 @@ def rolling_split(
     indices1d = tree.query_ball_point(
         np.transpose(n_1d_arrays(centers, 2)), r=size / 2, p=np.inf
     )
-    indices = [np.unravel_index(i, shape=shapes[0]) for i in indices1d]
+    # Need to convert the indices to int arrays because unravel_index doesn't
+    # like empty lists but can handle empty integer arrays in case a window has
+    # no points inside it.
+    indices = [
+        np.unravel_index(np.array(i, dtype="int"), shape=shapes[0]) for i in indices1d
+    ]
     return n_1d_arrays(centers, len(centers)), indices
 
 

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -863,14 +863,24 @@ def rolling_split(
     7.0, 7.0, 9.0, 9.0
     >>> # The points in the first window. Indices are 2D positions because the
     >>> # coordinate arrays are 2D.
-    >>> print(indices[0])
-    (array([0, 0, 0, 1, 1, 1, 2, 2, 2]), array([0, 1, 2, 0, 1, 2, 0, 1, 2]))
-    >>> print(indices[1])
-    (array([0, 0, 0, 1, 1, 1, 2, 2, 2]), array([2, 3, 4, 2, 3, 4, 2, 3, 4]))
-    >>> print(indices[2])
-    (array([2, 2, 2, 3, 3, 3, 4, 4, 4]), array([0, 1, 2, 0, 1, 2, 0, 1, 2]))
-    >>> print(indices[3])
-    (array([2, 2, 2, 3, 3, 3, 4, 4, 4]), array([2, 3, 4, 2, 3, 4, 2, 3, 4]))
+    >>> print(len(indices[0]))
+    2
+    >>> for dimension in indices[0]:
+    ...     print(dimension)
+    [0 0 0 1 1 1 2 2 2]
+    [0 1 2 0 1 2 0 1 2]
+    >>> for dimension in indices[1]:
+    ...     print(dimension)
+    [0 0 0 1 1 1 2 2 2]
+    [2 3 4 2 3 4 2 3 4]
+    >>> for dimension in indices[2]:
+    ...     print(dimension)
+    [2 2 2 3 3 3 4 4 4]
+    [0 1 2 0 1 2 0 1 2]
+    >>> for dimension in indices[3]:
+    ...     print(dimension)
+    [2 2 2 3 3 3 4 4 4]
+    [2 3 4 2 3 4 2 3 4]
     >>> # To get the coordinates for each window, use indexing
     >>> print(coords[0][indices[0]])
     [-5. -4. -3. -5. -4. -3. -5. -4. -3.]
@@ -881,14 +891,16 @@ def rolling_split(
 
     >>> coords1d = [coord.ravel() for coord in coords]
     >>> window_coords, indices = rolling_split(coords1d, size=2, spacing=2)
-    >>> print(indices[0])
-    (array([ 0,  1,  2,  5,  6,  7, 10, 11, 12]),)
-    >>> print(indices[1])
-    (array([ 2,  3,  4,  7,  8,  9, 12, 13, 14]),)
-    >>> print(indices[2])
-    (array([10, 11, 12, 15, 16, 17, 20, 21, 22]),)
-    >>> print(indices[3])
-    (array([12, 13, 14, 17, 18, 19, 22, 23, 24]),)
+    >>> print(len(indices[0]))
+    1
+    >>> print(indices[0][0])
+    [ 0  1  2  5  6  7 10 11 12]
+    >>> print(indices[1][0])
+    [ 2  3  4  7  8  9 12 13 14]
+    >>> print(indices[2][0])
+    [10 11 12 15 16 17 20 21 22]
+    >>> print(indices[3][0])
+    [12 13 14 17 18 19 22 23 24]
     >>> # The returned indices can be used in the same way as before
     >>> print(coords1d[0][indices[0]])
     [-5. -4. -3. -5. -4. -3. -5. -4. -3.]

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -737,7 +737,7 @@ def block_split(coordinates, spacing=None, adjust="spacing", region=None, shape=
     See also
     --------
     BlockReduce : Apply a reduction operation to the data in blocks (windows).
-    rolling_split : Split the given points on a rolling (moving) window.
+    rolling_window : Select points on a rolling (moving) window.
 
     Examples
     --------
@@ -781,11 +781,11 @@ def block_split(coordinates, spacing=None, adjust="spacing", region=None, shape=
     return n_1d_arrays(block_coords, len(block_coords)), labels
 
 
-def rolling_split(
+def rolling_window(
     coordinates, size, spacing=None, shape=None, region=None, adjust="spacing"
 ):
     """
-    Split the given points on a rolling (moving) window.
+    Select points on a rolling (moving) window.
 
     A window of the given size is moved across the region at a given step
     (specified by *spacing* or *shape*). Returns the indices of points falling
@@ -858,10 +858,10 @@ def rolling_split(
      [ 9.  9.  9.  9.  9.]
      [10. 10. 10. 10. 10.]]
     >>> # Get the rolling window indices
-    >>> window_coords, indices = rolling_split(coords, size=2, spacing=2)
+    >>> window_coords, indices = rolling_window(coords, size=2, spacing=2)
     >>> # Window coordinates will be 2D arrays. Their shape is the number of
     >>> # windows in each dimension
-    >>> print(window_coords[0].shape, window_coords[0].shape)
+    >>> print(window_coords[0].shape, window_coords[1].shape)
     (2, 2) (2, 2)
     >>> # The there are the easting and northing coordinates for the center of
     >>> # each rolling window
@@ -904,7 +904,7 @@ def rolling_split(
     If the coordinates are 1D, the indices will also be 1D:
 
     >>> coords1d = [coord.ravel() for coord in coords]
-    >>> window_coords, indices = rolling_split(coords1d, size=2, spacing=2)
+    >>> window_coords, indices = rolling_window(coords1d, size=2, spacing=2)
     >>> print(len(indices[0, 0]))
     1
     >>> print(indices[0, 0][0])
@@ -927,7 +927,7 @@ def rolling_split(
     >>> # Coordinates on a larger region but with the same spacing as before
     >>> coords = grid_coordinates((-10, 5, 0, 20), spacing=1)
     >>> # Get the rolling window indices but limited to the region from before
-    >>> window_coords, indices = rolling_split(
+    >>> window_coords, indices = rolling_window(
     ...     coords, size=2, spacing=2, region=(-5, -1, 6, 10),
     ... )
     >>> # The windows should still be in the same place as before

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -790,10 +790,10 @@ def rolling_split(
     inside each window step. You can use the indices to select points falling
     inside a given window.
 
-    The size of the windows can be specified by the *spacing* parameter.
-    Alternatively, the number of windows in the South-North and West-East
-    directions can be specified using the *shape* parameter. One of the two
-    must be given.
+    The size of the step when moving the windows can be specified by the
+    *spacing* parameter. Alternatively, the number of windows in the
+    South-North and West-East directions can be specified using the *shape*
+    parameter. **One of the two must be given.**
 
     Parameters
     ----------
@@ -801,6 +801,8 @@ def rolling_split(
         Arrays with the coordinates of each data point. Should be in the
         following order: (easting, northing, vertical, ...). Only easting and
         northing will be used, all subsequent coordinates will be ignored.
+    size : float
+        The size of the windows. Units should match the units of *coordinates*.
     spacing : float, tuple = (s_north, s_east), or None
         The window size in the South-North and West-East directions,
         respectively. A single value means that the size is equal in both

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -32,9 +32,9 @@ def test_rolling_split_empty():
     # so it doesn't pollute the test log.
     with warnings.catch_warnings(record=True):
         windows = rolling_split(coords, size=0.001, spacing=1, region=(-7, 1, 4, 12))[1]
-    assert windows[0][0].size == 0 and windows[0][1].size == 0
+    assert windows[0, 0][0].size == 0 and windows[0, 0][1].size == 0
     # Make sure we can still index with an empty array
-    assert coords[0][windows[0]].size == 0
+    assert coords[0][windows[0, 0]].size == 0
 
 
 def test_rolling_split_warnings():

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -30,6 +30,8 @@ def test_rolling_split_empty():
     # Use a larger region to make sure the first window is empty
     windows = rolling_split(coords, size=0.001, spacing=1, region=(-7, 1, 4, 12))[1]
     assert windows[0][0].size == 0 and windows[0][1].size == 0
+    # Make sure we can still index with an empty array
+    assert coords[0][windows[0]].size == 0
 
 
 def test_rolling_split_warnings():

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -11,7 +11,15 @@ from ..coordinates import (
     profile_coordinates,
     grid_coordinates,
     longitude_continuity,
+    rolling_split,
 )
+
+
+def test_rolling_split_invalid_coordinate_shapes():
+    "Shapes of input coordinates must all be the same"
+    coordinates = [np.arange(10), np.arange(10).reshape((5, 2))]
+    with pytest.raises(ValueError):
+        rolling_split(coordinates, size=2, spacing=1)
 
 
 def test_spacing_to_shape():

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -13,41 +13,43 @@ from ..coordinates import (
     profile_coordinates,
     grid_coordinates,
     longitude_continuity,
-    rolling_split,
+    rolling_window,
 )
 
 
-def test_rolling_split_invalid_coordinate_shapes():
+def test_rolling_window_invalid_coordinate_shapes():
     "Shapes of input coordinates must all be the same"
     coordinates = [np.arange(10), np.arange(10).reshape((5, 2))]
     with pytest.raises(ValueError):
-        rolling_split(coordinates, size=2, spacing=1)
+        rolling_window(coordinates, size=2, spacing=1)
 
 
-def test_rolling_split_empty():
+def test_rolling_window_empty():
     "Make sure empty windows return an empty index"
     coords = grid_coordinates((-5, -1, 6, 10), spacing=1)
     # Use a larger region to make sure the first window is empty
     # Doing this will raise a warning for non-overlapping windows. Capture it
     # so it doesn't pollute the test log.
     with warnings.catch_warnings(record=True):
-        windows = rolling_split(coords, size=0.001, spacing=1, region=(-7, 1, 4, 12))[1]
+        windows = rolling_window(coords, size=0.001, spacing=1, region=(-7, 1, 4, 12))[
+            1
+        ]
     assert windows[0, 0][0].size == 0 and windows[0, 0][1].size == 0
     # Make sure we can still index with an empty array
     assert coords[0][windows[0, 0]].size == 0
 
 
-def test_rolling_split_warnings():
+def test_rolling_window_warnings():
     "Should warn users if the windows don't overlap"
     coords = grid_coordinates((-5, -1, 6, 10), spacing=1)
     # For exact same size there will be 1 point overlapping so should not warn
     with warnings.catch_warnings(record=True) as warn:
-        rolling_split(coords, size=2, spacing=2)
+        rolling_window(coords, size=2, spacing=2)
         assert not any(issubclass(w.category, UserWarning) for w in warn)
     args = [dict(spacing=3), dict(spacing=(4, 1)), dict(shape=(1, 2))]
     for arg in args:
         with warnings.catch_warnings(record=True) as warn:
-            rolling_split(coords, size=2, **arg)
+            rolling_window(coords, size=2, **arg)
             # Filter out the user warnings from some deprecation warnings that
             # might be thrown by other packages.
             userwarnings = [w for w in warn if issubclass(w.category, UserWarning)]


### PR DESCRIPTION
The `rolling_window` function returns the indices of points falling on
rolling/moving windows. It works for irregularly sampled data and is a
nice complement to `xarray.DataArray.rolling`  (which only works on
grids). Uses a KDTree to select points but is not compatible with
pykdtree (it's missing the method we need).

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
