### PR TITLE
Generalize BaseGridder docstrings

### DIFF
--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -422,9 +422,12 @@ class BaseGridder(BaseEstimator):
         size : int
             The number of points to generate.
         dims : list or None
-            The names of the northing and easting data dimensions,
-            respectively, in the output dataframe. Defaults to ``['northing',
-            'easting']``. **NOTE: This is an exception to the "easting" then
+            The names of the northing/latitude and easting/longitude data
+            dimensions, respectively, in the output grid. Defaults are set
+            though ``dims`` class variable. Dims must be defined in the
+            following order: ``["northing", "easting"]`` or
+            ``["latitude", "longitude"]``.
+            **NOTE: This is an exception to the "easting" then
             "northing" pattern but is required for compatibility with xarray.**
         data_names : list of None
             The name(s) of the data variables in the output dataframe. Defaults

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -82,7 +82,7 @@ class BaseGridder(BaseEstimator):
     -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2
 
     """
-
+# The default dimension names for generated outputs (pd.DataFrame, xr.Dataset, etc)
     dims = ("northing", "easting")
 
     def predict(self, coordinates):

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -82,7 +82,9 @@ class BaseGridder(BaseEstimator):
     -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2, -32.2
 
     """
-# The default dimension names for generated outputs (pd.DataFrame, xr.Dataset, etc)
+
+    # The default dimension names for generated outputs
+    # (pd.DataFrame, xr.Dataset, etc)
     dims = ("northing", "easting")
 
     def predict(self, coordinates):
@@ -149,9 +151,9 @@ class BaseGridder(BaseEstimator):
         ----------
         coordinates : tuple of arrays
             Arrays with the coordinates of each data point. Should be in the
-            following order: (easting, northing, vertical, ...). 
-            For the specific definition of coordinate systems and what these 
-            names mean, see the class docstring. 
+            following order: (easting, northing, vertical, ...).
+            For the specific definition of coordinate systems and what these
+            names mean, see the class docstring.
         data : array or tuple of arrays
             The data values of each data point. If the data has more than one
             component, *data* must be a tuple of arrays (one for each

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -262,10 +262,10 @@ class BaseGridder(BaseEstimator):
             The grid spacing in the South-North and West-East directions,
             respectively.
         dims : list or None
-            The names of the northing/latitude and easting/longitude data
-            dimensions, respectively, in the output grid. Default is determined 
-            from the ``dims`` attribute of the class. Must be defined in the
-            following order: northing dimension, easting dimension.
+            The names of the northing and easting data dimensions,
+            respectively, in the output grid. Default is determined from the
+            ``dims`` attribute of the class. Must be defined in the following
+            order: northing dimension, easting dimension.
             **NOTE: This is an exception to the "easting" then
             "northing" pattern but is required for compatibility with xarray.**
         data_names : list of None
@@ -346,11 +346,10 @@ class BaseGridder(BaseEstimator):
             reproducible. Use ``None`` to choose a seed automatically
             (resulting in different numbers with each run).
         dims : list or None
-            The names of the northing/latitude and easting/longitude data
-            dimensions, respectively, in the output grid. Defaults are set
-            though ``dims`` class variable. Dims must be defined in the
-            following order: ``["northing", "easting"]`` or
-            ``["latitude", "longitude"]``.
+            The names of the northing and easting data dimensions,
+            respectively, in the output dataframe. Default is determined from
+            the ``dims`` attribute of the class. Must be defined in the
+            following order: northing dimension, easting dimension.
             **NOTE: This is an exception to the "easting" then
             "northing" pattern but is required for compatibility with xarray.**
         data_names : list of None
@@ -423,11 +422,10 @@ class BaseGridder(BaseEstimator):
         size : int
             The number of points to generate.
         dims : list or None
-            The names of the northing/latitude and easting/longitude data
-            dimensions, respectively, in the output grid. Defaults are set
-            though ``dims`` class variable. Dims must be defined in the
-            following order: ``["northing", "easting"]`` or
-            ``["latitude", "longitude"]``.
+            The names of the northing and easting data dimensions,
+            respectively, in the output dataframe. Default is determined from
+            the ``dims`` attribute of the class. Must be defined in the
+            following order: northing dimension, easting dimension.
             **NOTE: This is an exception to the "easting" then
             "northing" pattern but is required for compatibility with xarray.**
         data_names : list of None

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -338,7 +338,7 @@ class BaseGridder(BaseEstimator):
         Parameters
         ----------
         region : list = [W, E, S, N]
-            The boundaries of a given region.
+            The west, east, south, and north boundaries of a given region.
         size : int
             The number of points to generate.
         random_state : numpy.random.RandomState or an int seed

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -195,9 +195,9 @@ class BaseGridder(BaseEstimator):
         ----------
         coordinates : tuple of arrays
             Arrays with the coordinates of each data point. Should be in the
-            following order: (easting, northing, vertical, ...)
-            or (longitude, latitude, height, ...)
-            or (longitude, latitude, radius, ...).
+            following order: (easting, northing, vertical, ...).
+            For the specific definition of coordinate systems and what these
+            names mean, see the class docstring.
         data : array or tuple of arrays
             The data values of each data point. If the data has more than one
             component, *data* must be a tuple of arrays (one for each

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -465,16 +465,6 @@ class BaseGridder(BaseEstimator):
     def _get_dims(self, dims):
         """
         Get default dimension names.
-
-        Examples
-        --------
-
-        >>> gridder = BaseGridder()
-        >>> gridder._get_dims(dims=None)
-        ('northing', 'easting')
-        >>> gridder._get_dims(dims=('john', 'paul'))
-        ('john', 'paul')
-
         """
         if dims is not None:
             return dims

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -263,8 +263,8 @@ class BaseGridder(BaseEstimator):
             The names of the northing/latitude and easting/longitude data
             dimensions, respectively, in the output grid. Defaults are set
             though ``dims`` class variable. Dims must be defined in the
-            following order: ["northing", "easting"] or
-            ["latitude", "longitude"].
+            following order: ``["northing", "easting"]`` or
+            ``["latitude", "longitude"]``.
             **NOTE: This is an exception to the "easting" then
             "northing" pattern but is required for compatibility with xarray.**
         data_names : list of None
@@ -348,8 +348,8 @@ class BaseGridder(BaseEstimator):
             The names of the northing/latitude and easting/longitude data
             dimensions, respectively, in the output grid. Defaults are set
             though ``dims`` class variable. Dims must be defined in the
-            following order: ["northing", "easting"] or
-            ["latitude", "longitude"].
+            following order: ``["northing", "easting"]`` or
+            ``["latitude", "longitude"]``.
             **NOTE: This is an exception to the "easting" then
             "northing" pattern but is required for compatibility with xarray.**
         data_names : list of None

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -295,7 +295,7 @@ class BaseGridder(BaseEstimator):
         verde.grid_coordinates : Generate the coordinate values for the grid.
 
         """
-        dims = get_dims(self, dims)
+        dims = self._get_dims(dims)
         region = get_instance_region(self, region)
         coordinates = grid_coordinates(region, shape=shape, spacing=spacing, **kwargs)
         if projection is None:
@@ -374,7 +374,7 @@ class BaseGridder(BaseEstimator):
             The interpolated values on a random set of points.
 
         """
-        dims = get_dims(self, dims)
+        dims = self._get_dims(dims)
         region = get_instance_region(self, region)
         coordinates = scatter_points(region, size, random_state=random_state, **kwargs)
         if projection is None:
@@ -449,7 +449,7 @@ class BaseGridder(BaseEstimator):
             The interpolated values along the profile.
 
         """
-        dims = get_dims(self, dims)
+        dims = self._get_dims(dims)
         coordinates, distances = profile_coordinates(point1, point2, size, **kwargs)
         if projection is None:
             data = check_data(self.predict(coordinates))
@@ -464,24 +464,23 @@ class BaseGridder(BaseEstimator):
         columns.extend(zip(data_names, data))
         return pd.DataFrame(dict(columns), columns=[c[0] for c in columns])
 
+    def _get_dims(self, dims):
+        """
+        Get default dimension names.
 
-def get_dims(gridder, dims):
-    """
-    Get default dimension names.
+        Examples
+        --------
 
-    Examples
-    --------
+        >>> gridder = BaseGridder()
+        >>> gridder._get_dims(dims=None)
+        ('northing', 'easting')
+        >>> gridder._get_dims(dims=('john', 'paul'))
+        ('john', 'paul')
 
-    >>> gridder = BaseGridder()
-    >>> get_dims(gridder, dims=None)
-    ('northing', 'easting')
-    >>> get_dims(gridder, dims=('john', 'paul'))
-    ('john', 'paul')
-
-    """
-    if dims is not None:
-        return dims
-    return gridder.dims
+        """
+        if dims is not None:
+            return dims
+        return self.dims
 
 
 def get_data_names(data, data_names):

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -276,8 +276,7 @@ class BaseGridder(BaseEstimator):
             3D vector data.
         projection : callable or None
             If not None, then should be a callable object
-            ``projection(longitude, latitude) ->
-            (proj_easting, proj_northing)``
+            ``projection(easting, northing) -> (proj_easting, proj_northing)``
             that takes in easting and northing coordinate arrays and returns
             projected northing and easting coordinate arrays. This function
             will be used to project the generated grid coordinates before
@@ -360,8 +359,7 @@ class BaseGridder(BaseEstimator):
             3D vector data.
         projection : callable or None
             If not None, then should be a callable object
-            ``projection(longitude, latitude) ->
-            (proj_easting, proj_northing)``
+            ``projection(easting, northing) -> (proj_easting, proj_northing)``
             that takes in easting and northing coordinate arrays and returns
             projected northing and easting coordinate arrays. This function
             will be used to project the generated scatter coordinates before

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -149,9 +149,9 @@ class BaseGridder(BaseEstimator):
         ----------
         coordinates : tuple of arrays
             Arrays with the coordinates of each data point. Should be in the
-            following order: (easting, northing, vertical, ...)
-            or (longitude, latitude, height, ...)
-            or (longitude, latitude, radius, ...).
+            following order: (easting, northing, vertical, ...). 
+            For the specific definition of coordinate systems and what these 
+            names mean, see the class docstring. 
         data : array or tuple of arrays
             The data values of each data point. If the data has more than one
             component, *data* must be a tuple of arrays (one for each

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -252,7 +252,7 @@ class BaseGridder(BaseEstimator):
         Parameters
         ----------
         region : list = [W, E, S, N]
-            The boundaries of a given region.
+            The west, east, south, and north boundaries of a given region.
         shape : tuple = (n_north, n_east) or None
             The number of points in the South-North and West-East directions,
             respectively.

--- a/verde/tests/test_base.py
+++ b/verde/tests/test_base.py
@@ -1,4 +1,4 @@
-# pylint: disable=unused-argument,too-many-locals
+# pylint: disable=unused-argument,too-many-locals,protected-access
 """
 Test the base classes and their utility functions.
 """

--- a/verde/tests/test_base.py
+++ b/verde/tests/test_base.py
@@ -9,7 +9,6 @@ import pytest
 from ..base.utils import check_fit_input
 from ..base.base_classes import (
     BaseGridder,
-    get_dims,
     get_data_names,
     get_instance_region,
 )
@@ -19,10 +18,10 @@ from ..coordinates import grid_coordinates, scatter_points
 def test_get_dims():
     "Tests that get_dims returns the expected results"
     gridder = BaseGridder()
-    assert get_dims(gridder, dims=None) == ("northing", "easting")
-    assert get_dims(gridder, dims=("john", "paul")) == ("john", "paul")
+    assert gridder._get_dims(dims=None) == ("northing", "easting")
+    assert gridder._get_dims(dims=("john", "paul")) == ("john", "paul")
     gridder.dims = ("latitude", "longitude")
-    assert get_dims(gridder, dims=None) == ("latitude", "longitude")
+    assert gridder._get_dims(dims=None) == ("latitude", "longitude")
 
 
 def test_get_data_names():

--- a/verde/tests/test_base.py
+++ b/verde/tests/test_base.py
@@ -18,8 +18,11 @@ from ..coordinates import grid_coordinates, scatter_points
 
 def test_get_dims():
     "Tests that get_dims returns the expected results"
-    assert get_dims(dims=None) == ("northing", "easting")
-    assert get_dims(dims=("john", "paul")) == ("john", "paul")
+    gridder = BaseGridder()
+    assert get_dims(gridder, dims=None) == ("northing", "easting")
+    assert get_dims(gridder, dims=("john", "paul")) == ("john", "paul")
+    gridder.dims = ("latitude", "longitude")
+    assert get_dims(gridder, dims=None) == ("latitude", "longitude")
 
 
 def test_get_data_names():


### PR DESCRIPTION
Make docstrings of `BaseGridder` more general, without specifying
a coordinate system. Add `dims` as a class variable that will be used by
default on `grid`, `scatter` and `profile` methods.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Fixes #239





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
