### PR TITLE
Add optional argument to least_squares to copy Jacobian matrix

### DIFF
--- a/verde/base/least_squares.py
+++ b/verde/base/least_squares.py
@@ -7,7 +7,7 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.linear_model import LinearRegression, Ridge
 
 
-def least_squares(jacobian, data, weights, damping=None):
+def least_squares(jacobian, data, weights, damping=None, copy_jacobian=False):
     """
     Solve a weighted least-squares problem with optional damping regularization
 
@@ -16,6 +16,12 @@ def least_squares(jacobian, data, weights, damping=None):
     undone before returning the estimated parameters so that scaling isn't
     required for predictions. Doesn't normalize the column means because that
     operation can't be undone.
+
+    .. warning::
+
+        Setting `copy_jacobian` to True will copy the Jacobian matrix, doubling
+        the memory required. Use it only if Jacobian matrix is needed
+        afterwards.
 
     Parameters
     ----------
@@ -31,6 +37,9 @@ def least_squares(jacobian, data, weights, damping=None):
     damping : None or float
         The positive damping (Tikhonov 0th order) regularization parameter. If
         ``damping=None``, will use a regular least-squares fit.
+    copy_jacobian: bool
+        If False, the Jacobian matrix will be scaled inplace. If True, the
+        Jacobian matrix will be copied before scaling. Default False.
 
     Returns
     -------
@@ -44,7 +53,7 @@ def least_squares(jacobian, data, weights, damping=None):
                 jacobian.shape
             )
         )
-    scaler = StandardScaler(copy=False, with_mean=False, with_std=True)
+    scaler = StandardScaler(copy=copy_jacobian, with_mean=False, with_std=True)
     jacobian = scaler.fit_transform(jacobian)
     if damping is None:
         regr = LinearRegression(fit_intercept=False, normalize=False)

--- a/verde/base/least_squares.py
+++ b/verde/base/least_squares.py
@@ -20,7 +20,7 @@ def least_squares(jacobian, data, weights, damping=None, copy_jacobian=False):
     .. warning::
 
         Setting `copy_jacobian` to True will copy the Jacobian matrix, doubling
-        the memory required. Use it only if Jacobian matrix is needed
+        the memory required. Use it only if the Jacobian matrix is needed
         afterwards.
 
     Parameters

--- a/verde/tests/test_base.py
+++ b/verde/tests/test_base.py
@@ -6,6 +6,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
+from ..base.least_squares import least_squares
 from ..base.utils import check_fit_input, check_coordinates
 from ..base.base_classes import (
     BaseGridder,
@@ -232,3 +233,16 @@ def test_check_fit_input_fails_weights():
         check_fit_input(coords, data, weights)
     with pytest.raises(ValueError):
         check_fit_input(coords, (data, data), weights)
+
+
+def test_least_squares_copy_jacobian():
+    """
+    Test if Jacobian matrix is copied or scaled inplace
+    """
+    jacobian = np.identity(5)
+    original_jacobian = jacobian.copy()
+    data = np.array([1, 2, 3, 4, 5], dtype=float)
+    least_squares(jacobian, data, weights=None, copy_jacobian=True)
+    npt.assert_allclose(jacobian, original_jacobian)
+    least_squares(jacobian, data, weights=None)
+    assert not np.allclose(jacobian, original_jacobian)


### PR DESCRIPTION
Add new `copy_jacobian` optional argument to `least_squares` to avoid scaling Jacobian matrix inplace. Add warning on its docstring warning about memory consumption when `copy_jacobian` is True. Add test function for this new feature.

Fixes #252 

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
