### PR TITLE
Pin pylint to 2.4.*

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
     vmImage: 'ubuntu-16.04'
 
   variables:
-    CONDA_INSTALL_EXTRA: "black flake8 pylint"
+    CONDA_INSTALL_EXTRA: "black flake8 pylint==2.4.*"
     PYTHON: '3.7'
 
   steps:

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
     - pytest-mpl
     - coverage
     - black
-    - pylint
+    - pylint=2.4.*
     - flake8
     - sphinx=2.2.1
     - sphinx_rtd_theme=0.4.3


### PR DESCRIPTION
Version 2.5.0 introduced a bug with the multiprocessing option. This
happens often enough that we should have pylint pinned and only upgrade
when we choose to do it. See PyCQA/pylint#3524

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
