### PR TITLE
Update tests to new Scikit Learn gridders representation

### DIFF
--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -69,7 +69,7 @@ class BaseGridder(BaseEstimator):
     >>> # Fit the gridder to our synthetic data
     >>> grd = MeanGridder().fit((data.easting, data.northing), data.scalars)
     >>> grd
-    MeanGridder(multiplier=1)
+    MeanGridder()
     >>> # Interpolate on a regular grid
     >>> grid = grd.grid(region=(0, 5, -10, -8), shape=(30, 20))
     >>> np.allclose(grid.scalars, -32.2182)

--- a/verde/tests/test_base.py
+++ b/verde/tests/test_base.py
@@ -111,7 +111,7 @@ def test_basegridder():
         BaseGridder().fit(None, None)
 
     grd = PolyGridder()
-    assert repr(grd) == "PolyGridder(degree=1)"
+    assert repr(grd) == "PolyGridder()"
     grd.degree = 2
     assert repr(grd) == "PolyGridder(degree=2)"
 


### PR DESCRIPTION
Update tests functions to the new default representation of Scikit Learn
gridders. The expected outputs when printing Verde gridders has been
updated following this new default behaviour. After 0.23, Scikit Learn
only shows those parameters whose default value has been changed when
giving a string representation of the gridder. See
scikit-learn/scikit-learn#17061 and its changelog for more information.

Fix #266

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
