### PR TITLE
Ensure that cache folder exists before locate test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,6 +159,7 @@ Documentation for other versions
 * `Development <http://www.fatiando.org/verde/dev>`__ (reflects the *master* branch on
   Github)
 * `Latest release <http://www.fatiando.org/verde/latest>`__
+* `v1.5.0 <http://www.fatiando.org/verde/v1.5.0>`__
 * `v1.4.0 <http://www.fatiando.org/verde/v1.4.0>`__
 * `v1.3.0 <http://www.fatiando.org/verde/v1.3.0>`__
 * `v1.2.0 <http://www.fatiando.org/verde/v1.2.0>`__

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -3,6 +3,62 @@
 Changelog
 =========
 
+Version 1.5.0
+-------------
+
+*Released on: 2020/06/04*
+
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3877060.svg
+   :target: https://doi.org/10.5281/zenodo.3877060
+
+Bug fixes:
+
+* Apply projections using only the first two coordinates instead all given
+  coordinates. Projections only really involve the first two (horizontal)
+  coordinates. Only affects users passing ``extra_coords`` to gridder methods.
+  (`#264 <https://github.com/fatiando/verde/pull/264>`__)
+
+New features:
+
+* **New** blocked cross-validation classes ``BlockShuffleSplit`` and
+  ``BlockKFold``. These are scikit-learn compatible cross-validators that split
+  the data into spatial blocks before assigning them to folds. Blocked
+  cross-validation can help avoid overestimation of prediction accuracy for
+  spatial data (see [Roberts_etal2017]_). The classes work with
+  ``verde.cross_val_score`` and any other function/method/class that accepts a
+  scikit-learn cross-validator.
+  (`#251 <https://github.com/fatiando/verde/pull/251>`__ and
+  `#254 <https://github.com/fatiando/verde/pull/254>`__)
+* Add the option for block-wise splitting in ``verde.train_test_split`` by
+  passing in a ``spacing`` or ``shape`` parameters.
+  (`#253 <https://github.com/fatiando/verde/pull/253>`__ and
+  `#257 <https://github.com/fatiando/verde/pull/257>`__)
+
+Base classes:
+
+* Add optional argument to ``verde.base.least_squares`` to copy Jacobian
+  matrix.
+  (`#255 <https://github.com/fatiando/verde/pull/255>`__)
+* Add extra coordinates (specified by the ``extra_coords`` keyword argument
+  to outputs of ``BaseGridder`` methods.
+  (`#265 <https://github.com/fatiando/verde/pull/265>`__)
+
+Maintenance:
+
+* Update tests to ``repr`` changes in scikit-learn 0.23.0.
+  (`#267 <https://github.com/fatiando/verde/pull/267>`__)
+
+Documentation:
+
+* Fix typo in README contributing section.
+  (`#258 <https://github.com/fatiando/verde/pull/258>`__)
+
+This release contains contributions from:
+
+* Leonardo Uieda
+* Santiago Soler
+* Rowan Cockett
+
 Version 1.4.0
 -------------
 

--- a/verde/tests/test_datasets.py
+++ b/verde/tests/test_datasets.py
@@ -23,6 +23,9 @@ from ..datasets.sample_data import (
 
 def test_datasets_locate():
     "Make sure the data cache location has the right package name"
+    # Fetch a dataset first to make sure that the cache folder exists. Since
+    # Pooch 1.1.1 the cache isn't created until a download is requested.
+    fetch_texas_wind()
     path = locate()
     assert os.path.exists(path)
     # This is the most we can check in a platform independent way without


### PR DESCRIPTION
Since Pooch v1.1.1 the cache folder is only created when a `fetch` is
run. Our test was checking that the cache folder existed before doing
any downloads. So first make a download and then check.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
