### PR TITLE
Allow specifing the scoring function in cross_val_score

### DIFF
--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -5,12 +5,11 @@ from abc import ABCMeta, abstractmethod
 
 import xarray as xr
 import pandas as pd
-import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.model_selection import BaseCrossValidator
 
 from ..coordinates import grid_coordinates, profile_coordinates, scatter_points
-from .utils import check_data, check_fit_input, score_estimator
+from .utils import check_data, score_estimator
 
 
 # Pylint doesn't like X, y scikit-learn argument names.

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -8,10 +8,9 @@ import pandas as pd
 import numpy as np
 from sklearn.base import BaseEstimator
 from sklearn.model_selection import BaseCrossValidator
-from sklearn.metrics import r2_score
 
 from ..coordinates import grid_coordinates, profile_coordinates, scatter_points
-from .utils import check_data, check_fit_input
+from .utils import check_data, check_fit_input, score_estimator
 
 
 # Pylint doesn't like X, y scikit-learn argument names.
@@ -334,17 +333,7 @@ class BaseGridder(BaseEstimator):
             The R^2 score
 
         """
-        coordinates, data, weights = check_fit_input(
-            coordinates, data, weights, unpack=False
-        )
-        pred = check_data(self.predict(coordinates))
-        result = np.mean(
-            [
-                r2_score(datai.ravel(), predi.ravel(), sample_weight=weighti)
-                for datai, predi, weighti in zip(data, pred, weights)
-            ]
-        )
-        return result
+        return score_estimator("r2", self, coordinates, data, weights=weights)
 
     def grid(
         self,

--- a/verde/base/utils.py
+++ b/verde/base/utils.py
@@ -2,6 +2,80 @@
 Utility functions for building gridders and checking arguments.
 """
 import numpy as np
+from sklearn.metrics import check_scoring
+
+
+def score_estimator(scoring, estimator, coordinates, data, weights=None):
+    """
+    Score the given gridder against the given data using the given metric.
+
+    If the data and predictions have more than 1 component, the scores of each
+    component will be averaged.
+
+    Parameters
+    ----------
+    scoring : str or callable
+        A scoring specification known to scikit-learn. See
+        :func:`sklearn.metrics.check_scoring`.
+    estimator : a Verde gridder
+        The gridder to score. Usually derived from
+        :class:`verde.base.BaseGridder`.
+    coordinates : tuple of arrays
+        Arrays with the coordinates of each data point. Should be in the
+        following order: (easting, northing, vertical, ...).
+        For the specific definition of coordinate systems and what these
+        names mean, see the class docstring.
+    data : array or tuple of arrays
+        The data values of each data point. If the data has more than one
+        component, *data* must be a tuple of arrays (one for each
+        component).
+    weights : None or array or tuple of arrays
+        If not None, then the weights assigned to each data point. If more
+        than one data component is provided, you must provide a weights
+        array for each data component (if not None).
+
+    Returns
+    -------
+    score : float
+        The score.
+
+    """
+    coordinates, data, weights = check_fit_input(
+        coordinates, data, weights, unpack=False
+    )
+    predicted = check_data(estimator.predict(coordinates))
+    scorer = check_scoring(DummyEstimator, scoring=scoring)
+    result = np.mean(
+        [
+            scorer(
+                DummyEstimator(pred.ravel()),
+                coordinates,
+                data[i].ravel(),
+                sample_weight=weights[i],
+            )
+            for i, pred in enumerate(predicted)
+        ]
+    )
+    return result
+
+
+class DummyEstimator:
+    """
+    Dummy estimator that does nothing but pass along the predicted data.
+    Used to fool the scikit-learn scorer functions to fit our API
+    (multi-component estimators return a tuple on .predict).
+    """
+
+    def __init__(self, predicted):
+        self._predicted = predicted
+
+    def predict(self, *args, **kwargs):
+        "Return the stored predicted values"
+        return self._predicted
+
+    def fit(self, *args, **kwards):
+        "Does nothing. Just here to satisfy the API."
+        pass
 
 
 def check_data(data):

--- a/verde/base/utils.py
+++ b/verde/base/utils.py
@@ -64,18 +64,23 @@ class DummyEstimator:
     Dummy estimator that does nothing but pass along the predicted data.
     Used to fool the scikit-learn scorer functions to fit our API
     (multi-component estimators return a tuple on .predict).
+
+    >>> est = DummyEstimator([1, 2, 3])
+    >>> print(est.fit().predict())
+    [1, 2, 3]
+
     """
 
     def __init__(self, predicted):
         self._predicted = predicted
 
-    def predict(self, *args, **kwargs):
+    def predict(self, *args, **kwargs):  # pylint: disable=unused-argument
         "Return the stored predicted values"
         return self._predicted
 
-    def fit(self, *args, **kwards):
+    def fit(self, *args, **kwards):  # pylint: disable=unused-argument
         "Does nothing. Just here to satisfy the API."
-        pass
+        return self
 
 
 def check_data(data):

--- a/verde/model_selection.py
+++ b/verde/model_selection.py
@@ -609,6 +609,10 @@ def cross_val_score(
     cross-validation class from scikit-learn or Verde can be passed in through
     the *cv* argument.
 
+    The score is calculated using the estimator/gridder's ``.score`` method by
+    default. Alternatively, use the *scoring* parameter to specify a different
+    scoring function (e.g., mean square error, mean absolute error, etc).
+
     Can optionally run in parallel using :mod:`dask`. To do this, use
     ``delayed=True`` to dispatch computations with :func:`dask.delayed` instead
     of running them. The returned scores will be "lazy" objects instead of the
@@ -648,9 +652,11 @@ def cross_val_score(
         actually executing them. The returned scores will be a list of delayed
         objects. Call `.compute()` on each score or :func:`dask.compute` on the
         entire list to trigger the actual computations.
-    scoring : str or callable
-        A scoring specification known to scikit-learn. See
-        :func:`sklearn.metrics.check_scoring`.
+    scoring : None, str, or callable
+        A scoring function (or name of a function) known to scikit-learn. See
+        the description of *scoring* in
+        :func:`sklearn.model_selection.cross_val_score` for details. If None,
+        will fall back to the estimator's ``.score`` method.
 
     Returns
     -------
@@ -684,6 +690,22 @@ def cross_val_score(
 
     There are 5 scores because the default cross-validator is
     :class:`sklearn.model_selection.KFold` with ``n_splits=5``.
+
+    To calculate the score with a different metric, use the *scoring* argument:
+
+    >>> scores = cross_val_score(
+    ...     model, coords, data, scoring="neg_mean_squared_error",
+    ... )
+    >>> print(', '.join(['{:.2f}'.format(-score) for score in scores]))
+    0.00, 0.00, 0.00, 0.00, 0.00
+
+    In this case, we calculated the (negative) mean squared error (MSE) which
+    measures the distance between test data and predictions. This way, 0 is the
+    best possible value meaning that the data and prediction are the same. The
+    "neg" part indicates that this is the negative mean square error. This is
+    required because scikit-learn assumes that higher scores are always treated
+    as better (which is the opposite for MSE). For display, we take the
+    negative of the score to get the actual MSE.
 
     We can use different cross-validators by assigning them to the ``cv``
     argument:
@@ -747,12 +769,13 @@ def cross_val_score(
     fit_args = (coordinates, data, weights)
     scores = []
     for train_index, test_index in cv.split(feature_matrix):
-        train = tuple(select(i, train_index) for i in fit_args)
-        test = tuple(select(i, test_index) for i in fit_args)
         # Clone the estimator to avoid fitting the same object simultaneously
         # when delayed=True.
         score = dispatch(fit_score, client=client, delayed=delayed)(
-            clone(estimator), train, test, scoring
+            clone(estimator),
+            tuple(select(i, train_index) for i in fit_args),
+            tuple(select(i, test_index) for i in fit_args),
+            scoring,
         )
         scores.append(score)
     if not delayed and client is None:

--- a/verde/tests/test_model_selection.py
+++ b/verde/tests/test_model_selection.py
@@ -15,7 +15,7 @@ from ..model_selection import cross_val_score, BlockShuffleSplit, BlockKFold
 
 
 @pytest.fixture(name="trend")
-def fixtute_trend():
+def fixture_trend():
     "Coordinates and data for a 1-degree trend"
     coords = grid_coordinates((0, 10, -10, -5), spacing=0.1)
     coefs = (10, -1, 0.5)


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Currently, `cross_val_score` only uses the estimator's `.score` method (which is R² for all our gridders). But sometimes we want to use a different metric, like MSE or MAE. These changes allow passing in any scikit-learn compatible scorer through a new `scoring` parameter. This can be a string or callable, like in scikit-learn's `cross_val_score`. Needed to delegate score computation to a separate function in `verde.base.utils` to reuse in `cross_val_score` and a dummy class to be able to use the scikit-learn scorers correctly. 

**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [x] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [x] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
