### PR TITLE
Format the doc/conf.py file with Black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ PROJECT=verde
 TESTDIR=tmp-test-dir-with-unique-name
 PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs
 LINT_FILES=setup.py $(PROJECT)
-BLACK_FILES=setup.py $(PROJECT) examples data/examples tutorials
-FLAKE8_FILES=setup.py $(PROJECT) examples data/examples
+BLACK_FILES=setup.py $(PROJECT) examples data/examples doc/conf.py tutorials
+FLAKE8_FILES=setup.py $(PROJECT) examples data/examples doc/conf.py
 
 help:
 	@echo "Commands:"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,25 +5,20 @@ import datetime
 import sphinx_rtd_theme
 import sphinx_gallery
 from sphinx_gallery.sorting import FileNameSortKey
-
-# Sphinx needs to be able to import the package to use autodoc and get the
-# version number
-sys.path.append(os.path.pardir)
-
 from verde.version import full_version
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.coverage',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.doctest',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.extlinks',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.coverage",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.doctest",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
-    'matplotlib.sphinxext.plot_directive',
-    'sphinx.ext.napoleon',
-    'sphinx_gallery.gen_gallery',
+    "matplotlib.sphinxext.plot_directive",
+    "sphinx.ext.napoleon",
+    "sphinx_gallery.gen_gallery",
 ]
 
 # intersphinx configuration
@@ -45,62 +40,65 @@ autosummary_generate = []
 
 # Otherwise, the Return parameter list looks different from the Parameters list
 napoleon_use_rtype = False
-# Otherwise, the Attributes parameter list looks different from the Parameters list
+# Otherwise, the Attributes parameter list looks different from the Parameters
+# list
 napoleon_use_ivar = True
 
 sphinx_gallery_conf = {
     # path to your examples scripts
-    'examples_dirs': ['../examples', '../tutorials', '../data/examples'],
+    "examples_dirs": ["../examples", "../tutorials", "../data/examples"],
     # path where to save gallery generated examples
-    'gallery_dirs': ['gallery', 'tutorials', 'sample_data'],
-    'filename_pattern': '\.py',
+    "gallery_dirs": ["gallery", "tutorials", "sample_data"],
+    "filename_pattern": r"\.py",
     # Remove the "Download all examples" button from the top level gallery
-    'download_all_examples': False,
+    "download_all_examples": False,
     # Sort gallery example by file name instead of number of lines (default)
-    'within_subsection_order': FileNameSortKey,
+    "within_subsection_order": FileNameSortKey,
     # directory where function granular galleries are stored
-    'backreferences_dir': 'api/generated/backreferences',
+    "backreferences_dir": "api/generated/backreferences",
     # Modules for which function level galleries are created.  In
     # this case sphinx_gallery and numpy in a tuple of strings.
-    'doc_module': 'verde',
+    "doc_module": "verde",
     # Insert links to documentation of objects in the examples
-    'reference_url': {'verde': None},
+    "reference_url": {"verde": None},
 }
 
 # Always show the source code that generates a plot
 plot_include_source = True
-plot_formats = ['png']
+plot_formats = ["png"]
 
 # Sphinx project configuration
-templates_path = ['_templates']
-exclude_patterns = ['_build', '**.ipynb_checkpoints']
-source_suffix = '.rst'
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "**.ipynb_checkpoints"]
+source_suffix = ".rst"
 # The encoding of source files.
-source_encoding = 'utf-8-sig'
-master_doc = 'index'
+source_encoding = "utf-8-sig"
+master_doc = "index"
 
 # General information about the project
 year = datetime.date.today().year
-project = 'Verde'
-copyright = '2017-{}, The Verde Developers'.format(year)
-if len(full_version.split('+')) > 1 or full_version == 'unknown':
-    version = 'dev'
+project = "Verde"
+copyright = "2017-{}, The Verde Developers".format(year)
+if len(full_version.split("+")) > 1 or full_version == "unknown":
+    version = "dev"
 else:
     version = full_version
 
 # These enable substitutions using |variable| in the rst files
 rst_epilog = """
 .. |year| replace:: {year}
-""".format(year=year)
+""".format(
+    year=year
+)
 
-html_last_updated_fmt = '%b %d, %Y'
-html_title = 'Verde'
-html_short_title = 'Verde'
-html_logo = '_static/verde-logo.png'
-html_favicon = '_static/favicon.png'
-html_static_path = ['_static']
+html_last_updated_fmt = "%b %d, %Y"
+html_title = "Verde"
+html_short_title = "Verde"
+html_logo = "_static/verde-logo.png"
+html_favicon = "_static/favicon.png"
+html_static_path = ["_static"]
 html_extra_path = []
-pygments_style = 'default'
+pygments_style = "default"
 add_function_parentheses = False
 html_show_sourcelink = False
 html_show_sphinx = True
@@ -109,27 +107,41 @@ html_show_copyright = True
 # Theme config
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {
-    'logo_only': True,
-    'display_version': True,
+    "logo_only": True,
+    "display_version": True,
 }
 html_context = {
-    'menu_links_name': 'Getting help and contributing',
-    'menu_links': [
-        ('<i class="fa fa-external-link-square fa-fw"></i> Fatiando a Terra', 'https://www.fatiando.org'),
-        ('<i class="fa fa-users fa-fw"></i> Contributing', 'https://github.com/fatiando/verde/blob/master/CONTRIBUTING.md'),
-        ('<i class="fa fa-gavel fa-fw"></i> Code of Conduct', 'https://github.com/fatiando/verde/blob/master/CODE_OF_CONDUCT.md'),
-        ('<i class="fa fa-comment fa-fw"></i> Contact', 'http://contact.fatiando.org'),
-        ('<i class="fa fa-github fa-fw"></i> Source Code', 'https://github.com/fatiando/verde'),
+    "menu_links_name": "Getting help and contributing",
+    "menu_links": [
+        (
+            '<i class="fa fa-external-link-square fa-fw"></i> Fatiando a Terra',
+            "https://www.fatiando.org",
+        ),
+        (
+            '<i class="fa fa-users fa-fw"></i> Contributing',
+            "https://github.com/fatiando/verde/blob/master/CONTRIBUTING.md",
+        ),
+        (
+            '<i class="fa fa-gavel fa-fw"></i> Code of Conduct',
+            "https://github.com/fatiando/verde/blob/master/CODE_OF_CONDUCT.md",
+        ),
+        ('<i class="fa fa-comment fa-fw"></i> Contact', "http://contact.fatiando.org"),
+        (
+            '<i class="fa fa-github fa-fw"></i> Source Code',
+            "https://github.com/fatiando/verde",
+        ),
     ],
     # Custom variables to enable "Improve this page"" and "Download notebook"
     # links
-    'doc_path': 'doc',
-    'galleries': sphinx_gallery_conf['gallery_dirs'],
-    'gallery_dir': dict(zip(sphinx_gallery_conf['gallery_dirs'],
-                            sphinx_gallery_conf['examples_dirs'])),
-    'github_repo': 'fatiando/verde',
-    'github_version': 'master',
+    "doc_path": "doc",
+    "galleries": sphinx_gallery_conf["gallery_dirs"],
+    "gallery_dir": dict(
+        zip(sphinx_gallery_conf["gallery_dirs"], sphinx_gallery_conf["examples_dirs"])
+    ),
+    "github_repo": "fatiando/verde",
+    "github_version": "master",
 }
+
 
 # Load the custom CSS files (needs sphinx >= 1.6 for this to work)
 def setup(app):


### PR DESCRIPTION
Ran black on `doc/conf.py` and added it to the `black` and `flake8` runs
in the main Makefile. Removed the setting of `sys.path` since we're
installing the packaged in edit mode so it should be importable without
that hack.

Inspired on fatiando/rockhound#87
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
