### PR TITLE
Fix typos on docstrings

### DIFF
--- a/verde/distances.py
+++ b/verde/distances.py
@@ -15,7 +15,7 @@ def median_distance(coordinates, k_nearest=1, projection=None):
     distance to its *k_nearest* neighbors among the other points in the
     dataset. Sparse uniformly spaced datasets can use *k_nearest* of 1.
     Datasets with points clustered into tight groups (e.g., densely sampled
-    along a flight line or ship treck) will have very small distances to the
+    along a flight line or ship wreck) will have very small distances to the
     closest neighbors, which is not representative of the actual median spacing
     because it doesn't take the spacing between lines into account. In these
     cases, a median of the 10 or 20 nearest neighbors might be more

--- a/verde/model_selection.py
+++ b/verde/model_selection.py
@@ -86,7 +86,7 @@ class BlockShuffleSplit(BaseBlockCrossValidator):
         The number of splits generated per iteration to try to balance the
         amount of data in each set so that *test_size* and *train_size* are
         respected. If 1, then no extra splits are generated (essentially
-        disabling the balacing). Must be >= 1.
+        disabling the balancing). Must be >= 1.
 
     See also
     --------


### PR DESCRIPTION
Fix typos on functions docstrings from `distances.py` and
`model_selection.py`.

Fixes #287