### PR TITLE
Fix typos in docstrings

### DIFF
--- a/verde/distances.py
+++ b/verde/distances.py
@@ -15,7 +15,7 @@ def median_distance(coordinates, k_nearest=1, projection=None):
     distance to its *k_nearest* neighbors among the other points in the
     dataset. Sparse uniformly spaced datasets can use *k_nearest* of 1.
     Datasets with points clustered into tight groups (e.g., densely sampled
-    along a flight line or ship treck) will have very small distances to the
+    along a flight line or ship wreck) will have very small distances to the
     closest neighbors, which is not representative of the actual median spacing
     because it doesn't take the spacing between lines into account. In these
     cases, a median of the 10 or 20 nearest neighbors might be more

--- a/verde/distances.py
+++ b/verde/distances.py
@@ -15,7 +15,7 @@ def median_distance(coordinates, k_nearest=1, projection=None):
     distance to its *k_nearest* neighbors among the other points in the
     dataset. Sparse uniformly spaced datasets can use *k_nearest* of 1.
     Datasets with points clustered into tight groups (e.g., densely sampled
-    along a flight line or ship wreck) will have very small distances to the
+    along a flight line or ship track) will have very small distances to the
     closest neighbors, which is not representative of the actual median spacing
     because it doesn't take the spacing between lines into account. In these
     cases, a median of the 10 or 20 nearest neighbors might be more

--- a/verde/model_selection.py
+++ b/verde/model_selection.py
@@ -86,7 +86,7 @@ class BlockShuffleSplit(BaseBlockCrossValidator):
         The number of splits generated per iteration to try to balance the
         amount of data in each set so that *test_size* and *train_size* are
         respected. If 1, then no extra splits are generated (essentially
-        disabling the balacing). Must be >= 1.
+        disabling the balancing). Must be >= 1.
 
     See also
     --------


### PR DESCRIPTION
#### Description:

This pull-request Fixes #287.  It cherry-picks jcrawfords original work on this (seen in unmerged/closed pr #288) and adds the change requested by santisoler (in pr #288).


**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.

Let me know if this change could be accepted (or rejected) or needs some additional changes to be approved and merged.

Thank you,
DC Slagel
