### PR TITLE
Fix typo on "coordinates"

### DIFF
--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -165,7 +165,7 @@ class BaseGridder(BaseEstimator):
     ...     def __init__(self, multiplier=1):
     ...         # Init should only assign the parameters to attributes
     ...         self.multiplier = multiplier
-    ...     def fit(self, coordiantes, data):
+    ...     def fit(self, coordinates, data):
     ...         # Argument checking should be done in fit
     ...         if self.multiplier <= 0:
     ...             raise ValueError('Invalid multiplier {}'

--- a/verde/base/utils.py
+++ b/verde/base/utils.py
@@ -157,7 +157,7 @@ def check_coordinates(coordinates):
 
 def check_extra_coords_names(coordinates, extra_coords_names):
     """
-    Check extra_coords_names against coordiantes.
+    Check extra_coords_names against coordinates.
 
     Also, convert ``extra_coords_names`` to a tuple if it's a single string.
     Assume that there are extra coordinates on the ``coordinates`` tuple.

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -166,7 +166,7 @@ def test_check_region():
         check_region([-2, -1, -2, -3])
 
 
-def test_profile_coordiantes_fails():
+def test_profile_coordinates_fails():
     "Should raise an exception for invalid input"
     with pytest.raises(ValueError):
         profile_coordinates((0, 1), (1, 2), size=0)


### PR DESCRIPTION
Fix a common typo on Verde: replace "coordiantes" for "coordinates".





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
