### PR TITLE
Exclude Dask 2021.03.0 as a dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
     - xarray
     - scikit-learn
     - pooch
-    - dask
+    - dask!=2021.03.0
     # Optional
     - pykdtree
     - numba

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pandas
 xarray
 scikit-learn
 pooch>=0.7.0
-dask
+dask!=2021.03.0


### PR DESCRIPTION
Dask 2021.03.0 was causing the tests to fail under Python 3.8 on any OS.
The problem seems to be originated by `dask.distributed`.
By excluding this version, we avoid the problem in the future.

Fixes #310 


**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
