### PR TITLE
Get INSTALL_REQUIRES from requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,15 +43,8 @@ PACKAGE_DATA = {
     "verde.datasets": ["registry.txt"],
     "verde.tests": ["data/*", "baseline/*"],
 }
-INSTALL_REQUIRES = [
-    "numpy",
-    "scipy",
-    "pandas",
-    "xarray",
-    "scikit-learn",
-    "pooch>=0.7.0",
-    "dask",
-]
+with open("requirements.txt") as f:
+    INSTALL_REQUIRES = f.readlines()
 PYTHON_REQUIRES = ">=3.6"
 
 if __name__ == "__main__":


### PR DESCRIPTION
On `setup.py`, build the `INSTALL_REQUIRES` variable by reading the `requirements.txt` file.


**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
