### PR TITLE
Use keywords for default arguments in tests and examples

### DIFF
--- a/examples/vector_uncoupled.py
+++ b/examples/vector_uncoupled.py
@@ -69,7 +69,10 @@ print("Cross-validation R^2 score: {:.2f}".format(score))
 # Interpolate the wind speed onto a regular geographic grid and mask the data that are
 # outside of the convex hull of the data points.
 grid_full = chain.grid(
-    region, spacing=spacing, projection=projection, dims=["latitude", "longitude"]
+    region=region,
+    spacing=spacing,
+    projection=projection,
+    dims=["latitude", "longitude"],
 )
 grid = vd.convexhull_mask(coordinates, grid=grid_full, projection=projection)
 

--- a/verde/tests/test_base.py
+++ b/verde/tests/test_base.py
@@ -134,9 +134,9 @@ def test_basegridder():
         # A region should be given because it hasn't been assigned
         grd.grid()
 
-    coordinates_true = grid_coordinates(region, shape)
+    coordinates_true = grid_coordinates(region, shape=shape)
     data_true = angular * coordinates_true[0] + linear
-    grid = grd.grid(region, shape)
+    grid = grd.grid(region=region, shape=shape)
     prof = grd.profile((0, -10), (10, -10), 30)
 
     npt.assert_allclose(grd.coefs_, [linear, angular])
@@ -163,7 +163,7 @@ def test_basegridder_data_names():
     coordinates = scatter_points(region, 1000, random_state=0)
     data = angular * coordinates[0] + linear
     grd = PolyGridder().fit(coordinates, data)
-    grid = grd.grid(region, shape)
+    grid = grd.grid(region=region, shape=shape)
     prof = grd.profile((0, -10), (10, -10), 30)
     # Check if default name for data_names was applied correctly
     assert "scalars" in grid
@@ -205,7 +205,7 @@ def test_basegridder_projection():
     npt.assert_allclose(scat.northing, coordinates[1])
 
     # Check the grid
-    grid = grd.grid(region, shape, projection=proj)
+    grid = grd.grid(region=region, shape=shape, projection=proj)
     npt.assert_allclose(grid.scalars.values, data_true)
     npt.assert_allclose(grid.easting.values, coordinates_true[0][0, :])
     npt.assert_allclose(grid.northing.values, coordinates_true[1][:, 0])
@@ -318,7 +318,7 @@ def test_basegridder_projection_multiple_coordinates():
     npt.assert_allclose(grd.coefs_, [linear, angular / 2])
 
     # The actual values for a grid
-    coordinates_true = grid_coordinates(region, shape, extra_coords=(13, 17))
+    coordinates_true = grid_coordinates(region, shape=shape, extra_coords=(13, 17))
     data_true = angular * coordinates_true[0] + linear
 
     # Check the scatter
@@ -330,7 +330,7 @@ def test_basegridder_projection_multiple_coordinates():
     npt.assert_allclose(scat.northing, coordinates[1])
 
     # Check the grid
-    grid = grd.grid(region, shape, projection=proj, extra_coords=(13, 17))
+    grid = grd.grid(region=region, shape=shape, projection=proj, extra_coords=(13, 17))
     npt.assert_allclose(grid.scalars.values, data_true)
     npt.assert_allclose(grid.easting.values, coordinates_true[0][0, :])
     npt.assert_allclose(grid.northing.values, coordinates_true[1][:, 0])

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -69,8 +69,8 @@ def test_spline_cv(delayed, client, engine):
     # Tolerance needs to be kind of high to allow for error due to small
     # dataset
     npt.assert_allclose(
-        spline.grid(region, shape=shape).scalars,
-        synth.grid(region, shape=shape).scalars,
+        spline.grid(region=region, shape=shape).scalars,
+        synth.grid(region=region, shape=shape).scalars,
         rtol=5e-2,
     )
 
@@ -93,8 +93,8 @@ def test_spline():
     # Tolerance needs to be kind of high to allow for error due to small
     # dataset
     npt.assert_allclose(
-        spline.grid(region, shape=shape).scalars,
-        synth.grid(region, shape=shape).scalars,
+        spline.grid(region=region, shape=shape).scalars,
+        synth.grid(region=region, shape=shape).scalars,
         rtol=5e-2,
     )
 
@@ -141,8 +141,8 @@ def test_spline_damping():
     # Tolerance needs to be kind of high to allow for error due to small
     # dataset
     npt.assert_allclose(
-        spline.grid(region, shape=shape).scalars,
-        synth.grid(region, shape=shape).scalars,
+        spline.grid(region=region, shape=shape).scalars,
+        synth.grid(region=region, shape=shape).scalars,
         rtol=1e-2,
         atol=10,
     )


### PR DESCRIPTION
Explicitly pass default arguments with their corresponding keywords on tests
and examples. Particularly for grid_coordinates and BaseGridder.grid calls.
It's better if we instruct people to use keywords of default arguments instead
of passing them by order, this way can add or change the order of default
arguments without breaking backward compatibility.



**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
