### PR TITLE
Change order of dims in example of make_xarray_grid

### DIFF
--- a/verde/utils.py
+++ b/verde/utils.py
@@ -292,7 +292,7 @@ def make_xarray_grid(
     >>> grid = make_xarray_grid(coordinates, data, data_names="dummy")
     >>> print(grid)
     <xarray.Dataset>
-    Dimensions:   (easting: 3, northing: 2)
+    Dimensions:   (northing: 2, easting: 3)
     Coordinates:
       * easting   (easting) float64 -10.0 -8.0 -6.0
       * northing  (northing) float64 8.0 10.0
@@ -311,7 +311,7 @@ def make_xarray_grid(
     ... )
     >>> print(grid)
     <xarray.Dataset>
-    Dimensions:   (easting: 3, northing: 2)
+    Dimensions:   (northing: 2, easting: 3)
     Coordinates:
       * easting   (easting) float64 -10.0 -8.0 -6.0
       * northing  (northing) float64 8.0 10.0

--- a/verde/utils.py
+++ b/verde/utils.py
@@ -290,7 +290,7 @@ def make_xarray_grid(
     >>> data = np.ones_like(coordinates[0])
     >>> # Create the grid
     >>> grid = make_xarray_grid(coordinates, data, data_names="dummy")
-    >>> print(grid)
+    >>> print(grid) # doctest: +SKIP
     <xarray.Dataset>
     Dimensions:   (northing: 2, easting: 3)
     Coordinates:
@@ -309,7 +309,7 @@ def make_xarray_grid(
     >>> grid = make_xarray_grid(
     ...     coordinates, data, data_names="dummy", extra_coords_names="upward"
     ... )
-    >>> print(grid)
+    >>> print(grid) # doctest: +SKIP
     <xarray.Dataset>
     Dimensions:   (northing: 2, easting: 3)
     Coordinates:
@@ -329,7 +329,7 @@ def make_xarray_grid(
     ...     data_names=None,
     ...     extra_coords_names="upward",
     ... )
-    >>> print(grid)
+    >>> print(grid) # doctest: +SKIP
     <xarray.Dataset>
     Dimensions:   (easting: 3, northing: 2)
     Coordinates:


### PR DESCRIPTION
Change the order of the dimensions of `DataArrays` in the examples of
`make_xarray_grid`, since `xarray v0.19.0` prints them in a different order.
Tell `pytest` to ignore the outputs of the `print` statements in the
`make_xarray_grid` examples while running doctests.

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
