### PR TITLE
Fix broken Python 3.6 builds

### DIFF
--- a/env/requirements-build.txt
+++ b/env/requirements-build.txt
@@ -3,4 +3,4 @@ setuptools>=45
 wheel
 twine
 # TOML parser dropped 3.6 and is causing problems. Remove once we drop 3.6
-tomli>2.0.0
+tomli<2.0.0

--- a/env/requirements-build.txt
+++ b/env/requirements-build.txt
@@ -2,3 +2,5 @@ setuptools_scm>=6.2
 setuptools>=45
 wheel
 twine
+# TOML parser dropped 3.6 and is causing problems. Remove once we drop 3.6
+tomli>2.0.0


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

The [tomli](https://github.com/hukkin/tomli) package dropped 3.6 in it's 2.0.0 release and our dependencies didn't pin their upper versions. Restrict this to >2.0 for now until we drop Python 3.6. It's not a run-time dependency, only for building and testing.



**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
