### PR TITLE
Warn that the default score will change in 2.0

### DIFF
--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -323,6 +323,14 @@ class BaseGridder(BaseEstimator):
         predicted values and the given data values. A maximum score of 1 means
         a perfect fit. The score can be negative.
 
+        .. warning::
+
+            The default scoring will change from R² to negative root mean
+            squared error (RMSE) in Verde 2.0.0. This may change model
+            selection results slightly. The negative version will be used to
+            maintain the behaviour of larger scores being better, which is more
+            compatible with current model selection code.
+
         If the data has more than 1 component, the scores of each component
         will be averaged.
 
@@ -348,6 +356,12 @@ class BaseGridder(BaseEstimator):
             The R^2 score
 
         """
+        warnings.warn(
+            "The default scoring will change from R² to negative root mean "
+            "squared error (RMSE) in Verde 2.0.0. "
+            "This may change model selection results slightly.",
+            FutureWarning,
+        )
         return score_estimator("r2", self, coordinates, data, weights=weights)
 
     def grid(


### PR DESCRIPTION
Issue a warning in the code and docstring that the default scoring
method used in the `score` method will change from R² to negative root
mean squared error.

Fixes #340
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
