### PR TITLE
Move the CheckerBoard class to verde.synthetic

### DIFF
--- a/data/examples/checkerboard.py
+++ b/data/examples/checkerboard.py
@@ -8,7 +8,7 @@
 Checkerboard function
 =====================
 
-The :class:`verde.datasets.CheckerBoard` class generates synthetic data in a
+The :class:`verde.synthetic.CheckerBoard` class generates synthetic data in a
 checkerboard pattern. It has the same data generation methods that most
 gridders have: predict, grid, scatter, and profile.
 """
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 import verde as vd
 
 # Instantiate the data generator class and fit it to set the data region.
-synth = vd.datasets.CheckerBoard()
+synth = vd.synthetic.CheckerBoard()
 
 # Default values are provided for the wavelengths of the function determined
 # from the region.

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -103,6 +103,18 @@ Input/Output
 
     load_surfer
 
+.. automodule:: verde.synthetic
+
+.. currentmodule:: verde
+
+Synthetic data
+--------------
+
+.. autosummary::
+    :toctree: generated/
+
+    synthetic.CheckerBoard
+
 
 .. automodule:: verde.datasets
 
@@ -115,7 +127,6 @@ Datasets
    :toctree: generated/
 
     datasets.locate
-    datasets.CheckerBoard
     datasets.fetch_baja_bathymetry
     datasets.setup_baja_bathymetry_map
     datasets.fetch_california_gps

--- a/examples/project_grid.py
+++ b/examples/project_grid.py
@@ -49,7 +49,7 @@ projection = pyproj.Proj("epsg:3031")
 region = (0, 360, -90, -60)
 spacing = 0.25
 wavelength = 10 * 1e5  # The size of the cells in the checkerboard
-checkerboard = vd.datasets.CheckerBoard(
+checkerboard = vd.synthetic.CheckerBoard(
     region=vd.project_region(region, projection), w_east=wavelength, w_north=wavelength
 )
 data = checkerboard.grid(

--- a/tutorials/overview.py
+++ b/tutorials/overview.py
@@ -37,9 +37,9 @@ The library
 -----------
 
 Most classes and functions are available through the :mod:`verde` top level
-package. The only exceptions are the functions related to loading sample data,
-which are in :mod:`verde.datasets`. Throughout the documentation we'll use
-``vd`` as the alias for :mod:`verde`.
+package. The only exception is the :mod:`verde.synthetic` module that has
+functionality for generating synthetic data. Throughout the documentation we'll
+use ``vd`` as the alias for :mod:`verde`.
 
 """
 import matplotlib.pyplot as plt
@@ -66,9 +66,9 @@ import verde as vd
 # for spatial data and is common to all classes and functions in Verde.
 #
 # As an example, let's generate some synthetic data using
-# :class:`verde.datasets.CheckerBoard`:
+# :class:`verde.synthetic.CheckerBoard`:
 
-data = vd.datasets.CheckerBoard().scatter(size=500, random_state=0)
+data = vd.synthetic.CheckerBoard().scatter(size=500, random_state=0)
 print(data.head())
 
 
@@ -111,7 +111,7 @@ plt.show()
 # `R² coefficient of determination
 # <https://en.wikipedia.org/wiki/Coefficient_of_determination>`__.
 
-true_values = vd.datasets.CheckerBoard().predict(grid_coords)
+true_values = vd.synthetic.CheckerBoard().predict(grid_coords)
 print(spline.score(grid_coords, true_values))
 
 ###############################################################################

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -5,7 +5,7 @@
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
 # Import functions/classes to make the public API
-from . import datasets
+from . import datasets, synthetic
 from ._version import __version__
 from .blockreduce import BlockMean, BlockReduce
 from .chain import Chain

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -183,7 +183,7 @@ class BaseGridder(BaseEstimator):
     ...         check_is_fitted(self, ['mean_'])
     ...         return np.ones_like(coordinates[0])*self.mean_
     >>> # Try it on some synthetic data
-    >>> synthetic = vd.datasets.CheckerBoard(region=(0, 5, -10, 8))
+    >>> synthetic = vd.synthetic.CheckerBoard(region=(0, 5, -10, 8))
     >>> data = synthetic.scatter()
     >>> print('{:.4f}'.format(data.scalars.mean()))
     -32.2182

--- a/verde/datasets/synthetic.py
+++ b/verde/datasets/synthetic.py
@@ -7,112 +7,26 @@
 """
 Generators of synthetic datasets.
 """
-import numpy as np
+import warnings
 
-from ..base import BaseGridder
-from ..coordinates import check_region
+from ..synthetic import CheckerBoard as _CheckerBoard
 
 
-class CheckerBoard(BaseGridder):
-    r"""
-    Generate synthetic data in a checkerboard pattern.
+class CheckerBoard(_CheckerBoard):
+    """
+    .. warning::
 
-    The mathematical model is:
-
-    .. math::
-
-        f(e, n) = a
-        \sin\left(\frac{2\pi}{w_e} e\right)
-        \cos\left(\frac{2\pi}{w_n} n\right)
-
-    in which :math:`e` is the easting coordinate, :math:`n` is the northing
-    coordinate, :math:`a` is the amplitude, and :math:`w_e` and :math:`w_n` are
-    the wavelengths in the east and north directions, respectively.
-
-    Parameters
-    ----------
-    amplitude : float
-        The amplitude of the checkerboard undulations.
-    region : tuple
-        The boundaries (``[W, E, S, N]``) of the region used to generate the
-        synthetic data.
-    w_east : float
-        The wavelength in the east direction. Defaults to half of the West-East
-        size of the evaluating region.
-    w_north : float
-        The wavelength in the north direction. Defaults to half of the
-        South-North size of the evaluating region.
-
-    Examples
-    --------
-
-    >>> synth = CheckerBoard()
-    >>> # Default values for the wavelengths are selected automatically
-    >>> print(synth.w_east_, synth.w_north_)
-    2500.0 2500.0
-    >>> # CheckerBoard.grid produces an xarray.Dataset with data on a grid
-    >>> grid = synth.grid(shape=(11, 6))
-    >>> # scatter and profile generate pandas.DataFrame objects
-    >>> table = synth.scatter()
-    >>> print(sorted(table.columns))
-    ['easting', 'northing', 'scalars']
-    >>> profile = synth.profile(point1=(0, 0), point2=(2500, -2500), size=100)
-    >>> print(sorted(profile.columns))
-    ['distance', 'easting', 'northing', 'scalars']
+        Using ``CheckerBoard`` from ``verde.datasets`` is deprecated and will
+        be removed in Verde 2.0.0. Use ``verde.synthetic.CheckerBoard``
+        instead.
 
     """
 
-    def __init__(
-        self, amplitude=1000, region=(0, 5000, -5000, 0), w_east=None, w_north=None
-    ):
-        super().__init__()
-        self.amplitude = amplitude
-        self.w_east = w_east
-        self.w_north = w_north
-        self.region = region
-
-    @property
-    def w_east_(self):
-        "Use half of the E-W extent"
-        if self.w_east is None:
-            return (self.region[1] - self.region[0]) / 2
-        return self.w_east
-
-    @property
-    def w_north_(self):
-        "Use half of the N-S extent"
-        if self.w_north is None:
-            return (self.region[3] - self.region[2]) / 2
-        return self.w_north
-
-    @property
-    def region_(self):
-        "Used to fool the BaseGridder methods"
-        check_region(self.region)
-        return self.region
-
-    def predict(self, coordinates):
-        """
-        Evaluate the checkerboard function on a given set of points.
-
-        Parameters
-        ----------
-        coordinates : tuple of arrays
-            Arrays with the coordinates of each data point. Should be in the
-            following order: (easting, northing, vertical, ...). Only easting
-            and northing will be used, all subsequent coordinates will be
-            ignored.
-
-        Returns
-        -------
-        data : array
-            The evaluated checkerboard function.
-
-        """
-        easting, northing = coordinates[:2]
-        data = (
-            self.amplitude
-            * np.sin((2 * np.pi / self.w_east_) * easting)
-            * np.cos((2 * np.pi / self.w_north_) * northing)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        warnings.warn(
+            "Using CheckerBoard from verde.datasets is deprecated and will be "
+            "removed in Verde 2.0.0. "
+            "Use verde.synthetic.CheckerBoard instead.",
+            FutureWarning,
         )
-        return data

--- a/verde/synthetic.py
+++ b/verde/synthetic.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2017 The Verde Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+Generators of synthetic datasets.
+"""
+import numpy as np
+
+from .base import BaseGridder
+from .coordinates import check_region
+
+
+class CheckerBoard(BaseGridder):
+    r"""
+    Generate synthetic data in a checkerboard pattern.
+
+    The mathematical model is:
+
+    .. math::
+
+        f(e, n) = a
+        \sin\left(\frac{2\pi}{w_e} e\right)
+        \cos\left(\frac{2\pi}{w_n} n\right)
+
+    in which :math:`e` is the easting coordinate, :math:`n` is the northing
+    coordinate, :math:`a` is the amplitude, and :math:`w_e` and :math:`w_n` are
+    the wavelengths in the east and north directions, respectively.
+
+    Parameters
+    ----------
+    amplitude : float
+        The amplitude of the checkerboard undulations.
+    region : tuple
+        The boundaries (``[W, E, S, N]``) of the region used to generate the
+        synthetic data.
+    w_east : float
+        The wavelength in the east direction. Defaults to half of the West-East
+        size of the evaluating region.
+    w_north : float
+        The wavelength in the north direction. Defaults to half of the
+        South-North size of the evaluating region.
+
+    Examples
+    --------
+
+    >>> synth = CheckerBoard()
+    >>> # Default values for the wavelengths are selected automatically
+    >>> print(synth.w_east_, synth.w_north_)
+    2500.0 2500.0
+    >>> # CheckerBoard.grid produces an xarray.Dataset with data on a grid
+    >>> grid = synth.grid(shape=(11, 6))
+    >>> # scatter and profile generate pandas.DataFrame objects
+    >>> table = synth.scatter()
+    >>> print(sorted(table.columns))
+    ['easting', 'northing', 'scalars']
+    >>> profile = synth.profile(point1=(0, 0), point2=(2500, -2500), size=100)
+    >>> print(sorted(profile.columns))
+    ['distance', 'easting', 'northing', 'scalars']
+
+    """
+
+    def __init__(
+        self, amplitude=1000, region=(0, 5000, -5000, 0), w_east=None, w_north=None
+    ):
+        super().__init__()
+        self.amplitude = amplitude
+        self.w_east = w_east
+        self.w_north = w_north
+        self.region = region
+
+    @property
+    def w_east_(self):
+        "Use half of the E-W extent"
+        if self.w_east is None:
+            return (self.region[1] - self.region[0]) / 2
+        return self.w_east
+
+    @property
+    def w_north_(self):
+        "Use half of the N-S extent"
+        if self.w_north is None:
+            return (self.region[3] - self.region[2]) / 2
+        return self.w_north
+
+    @property
+    def region_(self):
+        "Used to fool the BaseGridder methods"
+        check_region(self.region)
+        return self.region
+
+    def predict(self, coordinates):
+        """
+        Evaluate the checkerboard function on a given set of points.
+
+        Parameters
+        ----------
+        coordinates : tuple of arrays
+            Arrays with the coordinates of each data point. Should be in the
+            following order: (easting, northing, vertical, ...). Only easting
+            and northing will be used, all subsequent coordinates will be
+            ignored.
+
+        Returns
+        -------
+        data : array
+            The evaluated checkerboard function.
+
+        """
+        easting, northing = coordinates[:2]
+        data = (
+            self.amplitude
+            * np.sin((2 * np.pi / self.w_east_) * easting)
+            * np.cos((2 * np.pi / self.w_north_) * northing)
+        )
+        return data

--- a/verde/tests/test_chain.py
+++ b/verde/tests/test_chain.py
@@ -13,9 +13,9 @@ import numpy.testing as npt
 from ..blockreduce import BlockReduce
 from ..chain import Chain
 from ..coordinates import grid_coordinates
-from ..synthetic import CheckerBoard
 from ..scipygridder import ScipyGridder
 from ..spline import Spline
+from ..synthetic import CheckerBoard
 from ..trend import Trend
 from ..vector import Vector
 

--- a/verde/tests/test_chain.py
+++ b/verde/tests/test_chain.py
@@ -13,7 +13,7 @@ import numpy.testing as npt
 from ..blockreduce import BlockReduce
 from ..chain import Chain
 from ..coordinates import grid_coordinates
-from ..datasets.synthetic import CheckerBoard
+from ..synthetic import CheckerBoard
 from ..scipygridder import ScipyGridder
 from ..spline import Spline
 from ..trend import Trend

--- a/verde/tests/test_scipy.py
+++ b/verde/tests/test_scipy.py
@@ -15,8 +15,8 @@ import pandas as pd
 import pytest
 
 from ..coordinates import grid_coordinates
-from ..synthetic import CheckerBoard
 from ..scipygridder import ScipyGridder
+from ..synthetic import CheckerBoard
 
 
 def test_scipy_gridder_same_points():

--- a/verde/tests/test_scipy.py
+++ b/verde/tests/test_scipy.py
@@ -15,7 +15,7 @@ import pandas as pd
 import pytest
 
 from ..coordinates import grid_coordinates
-from ..datasets.synthetic import CheckerBoard
+from ..synthetic import CheckerBoard
 from ..scipygridder import ScipyGridder
 
 

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -15,7 +15,7 @@ import pytest
 from dask.distributed import Client
 from sklearn.model_selection import ShuffleSplit
 
-from ..datasets.synthetic import CheckerBoard
+from ..synthetic import CheckerBoard
 from ..spline import Spline, SplineCV
 from .utils import requires_numba
 

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -15,8 +15,8 @@ import pytest
 from dask.distributed import Client
 from sklearn.model_selection import ShuffleSplit
 
-from ..synthetic import CheckerBoard
 from ..spline import Spline, SplineCV
+from ..synthetic import CheckerBoard
 from .utils import requires_numba
 
 

--- a/verde/tests/test_vector.py
+++ b/verde/tests/test_vector.py
@@ -13,7 +13,7 @@ import pytest
 
 from ..base import n_1d_arrays
 from ..coordinates import grid_coordinates
-from ..datasets.synthetic import CheckerBoard
+from ..synthetic import CheckerBoard
 from ..trend import Trend
 from ..vector import Vector, VectorSpline2D
 from .utils import requires_numba


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->
Create a new module `verde.synthetic` to house the `CheckerBoard` class. The module is imported in `__init__.py` and a version of `CheckerBoard` is maintained in `verde.datasets` that issues a warning when used. 

Fixes #349 




**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
