### PR TITLE
Modernize the front page of the docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,30 +29,16 @@ Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 About
 -----
 
-Verde is a Python library for processing spatial data (bathymetry, geophysics
-surveys, etc) and interpolating it on regular grids (i.e., *gridding*).
+**Verde** is a Python library for processing spatial data (bathymetry,
+geophysics surveys, etc) and interpolating it on regular grids (i.e.,
+*gridding*).
 
-Most gridding methods in Verde use a Green's functions approach.
-A linear model is estimated based on the input data and then used to predict
-data on a regular grid (or in a scatter, a profile, as derivatives).
-The models are Green's functions from (mostly) elastic deformation theory.
-This approach is very similar to *machine learning* so we implement gridder
-classes that are similar to `scikit-learn <http://scikit-learn.org/>`__
-regression classes.
-The API is not 100% compatible but it should look familiar to those with some
-scikit-learn experience.
-
-Advantages of using Green's functions include:
-
-* Easily apply **weights** to data points. This is a linear least-squares
-  problem.
-* Perform **model selection** using established machine learning techniques,
-  like k-fold or holdout cross-validation.
-* The estimated model can be **easily stored** for later use, like
-  spherical-harmonic coefficients are used in gravimetry.
-
-The main disadvantage is the heavy memory and processing time requirement (it's
-a linear regression problem).
+Our core interpolation methods are inspired by machine-learning.
+As such, Verde implements an interface that is similar to the popular
+`scikit-learn <https://scikit-learn.org/>`__ library.
+We also provide other analysis methods that are often used in combination with
+gridding, like trend removal, blocked/windowed operations, cross-validation,
+and more!
 
 
 Project goals
@@ -64,10 +50,11 @@ Project goals
 * Support for gridding scalar and vector data (like wind speed or GPS velocities)
 * Support for both Cartesian and geographic coordinates
 
-The first release of Verde was focused on meeting these initial goals and establishing
-the look and feel of the library. Later releases will focus on expanding the range of
-gridders available, optimizing the code, and improving algorithms so that
-larger-than-memory datasets can also be supported.
+The first release of Verde was focused on meeting most of these initial goals
+and establishing the look and feel of the library.
+Later releases will focus on expanding the range of gridders available,
+optimizing the code, and improving algorithms so that larger-than-memory
+datasets can also be supported.
 
 
 Contacting us
@@ -139,20 +126,3 @@ License
 This is free software: you can redistribute it and/or modify it under the terms
 of the **BSD 3-clause License**. A copy of this license is provided in
 `LICENSE.txt <https://github.com/fatiando/verde/blob/main/LICENSE.txt>`__.
-
-
-Documentation for other versions
---------------------------------
-
-* `Development <http://www.fatiando.org/verde/dev>`__ (reflects the *main* branch on
-  Github)
-* `Latest release <http://www.fatiando.org/verde/latest>`__
-* `v1.6.1 <http://www.fatiando.org/verde/v1.6.1>`__
-* `v1.6.0 <http://www.fatiando.org/verde/v1.6.0>`__
-* `v1.5.0 <http://www.fatiando.org/verde/v1.5.0>`__
-* `v1.4.0 <http://www.fatiando.org/verde/v1.4.0>`__
-* `v1.3.0 <http://www.fatiando.org/verde/v1.3.0>`__
-* `v1.2.0 <http://www.fatiando.org/verde/v1.2.0>`__
-* `v1.1.0 <http://www.fatiando.org/verde/v1.1.0>`__
-* `v1.0.1 <http://www.fatiando.org/verde/v1.0.1>`__
-* `v1.0.0 <http://www.fatiando.org/verde/v1.0.0>`__

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -1,7 +1,7 @@
 .. _api:
 
-API Reference
-=============
+List of functions and classes (API)
+===================================
 
 .. automodule:: verde
 
@@ -88,7 +88,6 @@ Utilities
 .. autosummary::
    :toctree: generated/
 
-    test
     maxabs
     variance_to_weights
     grid_to_table

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,35 +8,91 @@
     :alt: Verde Documentation
     :align: middle
 
-.. raw:: html
+**Verde** is a Python library for processing spatial data (bathymetry,
+geophysics surveys, etc) and interpolating it on regular grids (i.e.,
+*gridding*).
 
-    <p class="lead text-center front-page-callout">
-        Processing and gridding spatial data
-    </p>
+Our core interpolation methods are inspired by machine-learning. As such, Verde
+implements an interface that is similar to the popular
+`scikit-learn <https://scikit-learn.org/>`__ library.
+We also provide other analysis methods that are often used in combination with
+gridding, like trend removal, blocked/windowed operations, cross-validation,
+and more!
+
+
+.. panels::
+    :header: text-center text-large
+    :card: border-1 m-1 text-center
+
+    **Getting started**
+    ^^^^^^^^^^^^^^^^^^^
+
+    New to Verde? Start here!
+
+    .. link-button:: overview
+        :type: ref
+        :text: Overview
+        :classes: btn-outline-primary btn-block stretched-link
+
+    ---
+
+    **Need help?**
+    ^^^^^^^^^^^^^^
+
+    Ask on our community channels
+
+    .. link-button:: https://www.fatiando.org/contact
+        :type: url
+        :text: Join the conversation
+        :classes: btn-outline-primary btn-block stretched-link
+
+    ---
+
+    **Reference documentation**
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    A list of modules and functions
+
+    .. link-button:: api
+        :type: ref
+        :text: API reference
+        :classes: btn-outline-primary btn-block stretched-link
+
+    ---
+
+    **Using Verde for research?**
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    Citations help support our work
+
+    .. link-button:: citing
+        :type: ref
+        :text: Cite Verde
+        :classes: btn-outline-primary btn-block stretched-link
+
 
 .. seealso::
 
     Verde is a part of the
-    `Fatiando a Terra <https://www.fatiando.org/>`_ project.
+    `Fatiando a Terra <https://www.fatiando.org/>`__ project.
 
 
-.. include:: ../README.rst
-    :start-after: placeholder-for-doc-index
+----
 
+
+Table of contents
+-----------------
 
 .. toctree::
-    :maxdepth: 2
-    :hidden:
+    :maxdepth: 1
     :caption: Getting Started
 
     tutorials/overview.rst
     install.rst
-    citing.rst
     gallery/index.rst
 
 .. toctree::
-    :maxdepth: 2
-    :hidden:
+    :maxdepth: 1
     :caption: User Guide
 
     sample_data/index.rst
@@ -51,17 +107,17 @@
     tutorials/vectors.rst
 
 .. toctree::
-    :maxdepth: 2
-    :hidden:
+    :maxdepth: 1
     :caption: Reference documentation
 
     api/index.rst
+    citing.rst
     changes.rst
     references.rst
+    versions.rst
 
 .. toctree::
-    :maxdepth: 2
-    :hidden:
+    :maxdepth: 1
     :caption: Community
 
     Join the community <https://www.fatiando.org/contact/>

--- a/doc/versions.rst
+++ b/doc/versions.rst
@@ -1,0 +1,19 @@
+Documentation for other versions
+--------------------------------
+
+Use the links below to access documentation for specific versions
+(when in doubt, use the **latest release**):
+
+* `Latest release <http://www.fatiando.org/verde/latest>`__
+* `Development <http://www.fatiando.org/verde/dev>`__
+  (reflects the *main* branch on GitHub)
+* `v1.6.1 <http://www.fatiando.org/verde/v1.6.1>`__
+* `v1.6.0 <http://www.fatiando.org/verde/v1.6.0>`__
+* `v1.5.0 <http://www.fatiando.org/verde/v1.5.0>`__
+* `v1.4.0 <http://www.fatiando.org/verde/v1.4.0>`__
+* `v1.3.0 <http://www.fatiando.org/verde/v1.3.0>`__
+* `v1.2.0 <http://www.fatiando.org/verde/v1.2.0>`__
+* `v1.1.0 <http://www.fatiando.org/verde/v1.1.0>`__
+* `v1.0.1 <http://www.fatiando.org/verde/v1.0.1>`__
+* `v1.0.0 <http://www.fatiando.org/verde/v1.0.0>`__
+

--- a/verde/synthetic.py
+++ b/verde/synthetic.py
@@ -4,9 +4,6 @@
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
-"""
-Generators of synthetic datasets.
-"""
 import numpy as np
 
 from .base import BaseGridder


### PR DESCRIPTION
Use sphinx-panels to make the 4 box callouts to sections of the docs.
Stop reusing the README and instead have a single paragraph explaining
what Verde is. Reuse this paragraph in the README since that one needed
some updating as well. Move the links to other versions of the docs into
it's own page. Rename the API reference to something more informative.
Remove the deprecated `test` function from the API reference.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
