### PR TITLE
Replace deprecated numpy dtypes np.bool and np.int

### DIFF
--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -696,8 +696,8 @@ def inside(coordinates, region):
     w, e, s, n = region
     easting, northing = coordinates[:2]
     # Allocate temporary arrays to minimize memory allocation overhead
-    out = np.empty_like(easting, dtype=np.bool)
-    tmp = tuple(np.empty_like(easting, dtype=np.bool) for i in range(4))
+    out = np.empty_like(easting, dtype=bool)
+    tmp = tuple(np.empty_like(easting, dtype=bool) for i in range(4))
     # Using the logical functions is a lot faster than & > < for some reason
     # Plus, this way avoids repeated allocation of intermediate arrays
     in_we = np.logical_and(

--- a/verde/trend.py
+++ b/verde/trend.py
@@ -192,13 +192,13 @@ class Trend(BaseGridder):
         >>> import numpy as np
         >>> east = np.linspace(0, 4, 5)
         >>> north = np.linspace(-5, -1, 5)
-        >>> print(Trend(degree=1).jacobian((east, north), dtype=np.int))
+        >>> print(Trend(degree=1).jacobian((east, north), dtype=int))
         [[ 1  0 -5]
          [ 1  1 -4]
          [ 1  2 -3]
          [ 1  3 -2]
          [ 1  4 -1]]
-        >>> print(Trend(degree=2).jacobian((east, north), dtype=np.int))
+        >>> print(Trend(degree=2).jacobian((east, north), dtype=int))
         [[ 1  0 -5  0  0 25]
          [ 1  1 -4  1 -4 16]
          [ 1  2 -3  4 -6  9]


### PR DESCRIPTION
**Description**

Numpy dtypes like `np.bool` and `np.int` have been deprecated since Numpy v1.2.0 in favor of using
builtin `bool` or `int`, or even `np.int64` and `np.int32` which explicitly
sets their precision.

See https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated
for a list of deprecated data types.