### PR TITLE
Add a Linear gridder class based on SciPy

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -15,6 +15,7 @@ Interpolators
 
     Spline
     SplineCV
+    Linear
     VectorSpline2D
     ScipyGridder
 

--- a/doc/gallery_src/linear_gridder.py
+++ b/doc/gallery_src/linear_gridder.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2017 The Verde Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+Gridding with a linear interpolator
+===================================
+
+Verde offers the :class:`verde.Linear` class for piecewise linear gridding.
+It uses :class:`scipy.interpolate.LinearNDInterpolator` under the hood while
+offering the convenience of Verde's gridder API.
+
+The interpolation works on Cartesian data, so if we want to grid geographic
+data (like our Baja California bathymetry) we need to project them into a
+Cartesian system. We'll use `pyproj <https://github.com/jswhit/pyproj>`__ to
+calculate a Mercator projection for the data.
+
+For convenience, Verde still allows us to make geographic grids by passing the
+``projection`` argument to :meth:`verde.Linear.grid` and the like. When
+doing so, the grid will be generated using geographic coordinates which will be
+projected prior to interpolation.
+"""
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+import numpy as np
+import pyproj
+
+import verde as vd
+
+# We'll test this on the Baja California shipborne bathymetry data
+data = vd.datasets.fetch_baja_bathymetry()
+
+# Before gridding, we need to decimate the data to avoid aliasing because of
+# the oversampling along the ship tracks. We'll use a blocked median with 5
+# arc-minute blocks.
+spacing = 1 / 60
+reducer = vd.BlockReduce(reduction=np.median, spacing=spacing)
+coordinates, bathymetry = reducer.filter(
+    (data.longitude, data.latitude), data.bathymetry_m
+)
+
+# Project the data using pyproj so that we can use it as input for the gridder.
+# We'll set the latitude of true scale to the mean latitude of the data.
+projection = pyproj.Proj(proj="merc", lat_ts=data.latitude.mean())
+proj_coordinates = projection(*coordinates)
+
+# Now we can set up a gridder for the decimated data
+grd = vd.Linear().fit(proj_coordinates, bathymetry)
+
+# Get the grid region in geographic coordinates
+region = vd.get_region((data.longitude, data.latitude))
+print("Data region:", region)
+
+# The 'grid' method can still make a geographic grid if we pass in a projection
+# function that converts lon, lat into the easting, northing coordinates that
+# we used in 'fit'. This can be any function that takes lon, lat and returns x,
+# y. In our case, it'll be the 'projection' variable that we created above.
+# We'll also set the names of the grid dimensions and the name the data
+# variable in our grid (the default would be 'scalars', which isn't very
+# informative).
+grid = grd.grid(
+    region=region,
+    spacing=spacing,
+    projection=projection,
+    dims=["latitude", "longitude"],
+    data_names="bathymetry_m",
+)
+print("Generated geographic grid:")
+print(grid)
+
+# Cartopy requires setting the coordinate reference system (CRS) of the
+# original data through the transform argument. Their docs say to use
+# PlateCarree to represent geographic data.
+crs = ccrs.PlateCarree()
+
+plt.figure(figsize=(7, 6))
+# Make a Mercator map of our gridded bathymetry
+ax = plt.axes(projection=ccrs.Mercator())
+# Plot the gridded bathymetry
+pc = grid.bathymetry_m.plot.pcolormesh(
+    ax=ax, transform=crs, vmax=0, zorder=-1, add_colorbar=False
+)
+plt.colorbar(pc).set_label("meters")
+# Plot the locations of the decimated data
+ax.plot(*coordinates, ".k", markersize=0.1, transform=crs)
+# Use an utility function to setup the tick labels and the land feature
+vd.datasets.setup_baja_bathymetry_map(ax)
+ax.set_title("Linear gridding of bathymetry")
+plt.show()

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -31,7 +31,7 @@ from .model_selection import (
     train_test_split,
 )
 from .projections import project_grid, project_region
-from .scipygridder import ScipyGridder
+from .scipygridder import Linear, ScipyGridder
 from .spline import Spline, SplineCV
 from .trend import Trend
 from .utils import grid_to_table, make_xarray_grid, maxabs, variance_to_weights

--- a/verde/scipygridder.py
+++ b/verde/scipygridder.py
@@ -5,8 +5,9 @@
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
 """
-A gridder that uses scipy.interpolate as the backend.
+Gridders that use scipy.interpolate as the backend.
 """
+from abc import abstractmethod
 from warnings import warn
 
 import numpy as np
@@ -21,7 +22,135 @@ from .base import BaseGridder, check_fit_input
 from .coordinates import get_region
 
 
-class ScipyGridder(BaseGridder):
+class _BaseScipyGridder(BaseGridder):
+    """
+    A scipy.interpolate base gridder for scalar Cartesian data.
+
+    Used as a base class for each of the SciPy ND based interpolators.
+
+    Attributes
+    ----------
+    interpolator_ : scipy interpolator class
+        An instance of the corresponding scipy interpolator class.
+    region_ : tuple
+        The boundaries (``[W, E, S, N]``) of the data used to fit the
+        interpolator. Used as the default region for the
+        :meth:`~verde.ScipyGridder.grid` and
+        :meth:`~verde.ScipyGridder.scatter` methods.
+
+    """
+
+    @abstractmethod
+    def _get_interpolator(self):
+        """
+        Return the SciPy interpolator class and any extra keyword arguments as
+        a dictionary.
+        """
+
+    def fit(self, coordinates, data, weights=None):
+        """
+        Fit the interpolator to the given data.
+
+        The data region is captured and used as default for the
+        :meth:`~verde._BaseScipyGridder.grid` method.
+
+        Parameters
+        ----------
+        coordinates : tuple of arrays
+            Arrays with the coordinates of each data point. Should be in the
+            following order: (easting, northing, vertical, ...). Only easting
+            and northing will be used, all subsequent coordinates will be
+            ignored.
+        data : array
+            The data values that will be interpolated.
+        weights : None or array
+            Data weights are **not supported** by this interpolator and will be
+            ignored. Only present for compatibility with other gridder.
+
+        Returns
+        -------
+        self
+            Returns this gridder instance for chaining operations.
+
+        """
+        if weights is not None:
+            warn(
+                "{} does not support weights and they will be ignored.".format(
+                    self.__class__.__name__
+                )
+            )
+        coordinates, data, weights = check_fit_input(coordinates, data, weights)
+        easting, northing = coordinates[:2]
+        self.region_ = get_region((easting, northing))
+        points = np.column_stack((np.ravel(easting), np.ravel(northing)))
+        interpolator_class, kwargs = self._get_interpolator()
+        self.interpolator_ = interpolator_class(points, np.ravel(data), **kwargs)
+        return self
+
+    def predict(self, coordinates):
+        """
+        Interpolate data on the given set of points.
+
+        Requires a fitted gridder (see :meth:`~verde._BaseScipyGridder.fit`).
+
+        Parameters
+        ----------
+        coordinates : tuple of arrays
+            Arrays with the coordinates of each data point. Should be in the
+            following order: (easting, northing, vertical, ...). Only easting
+            and northing will be used, all subsequent coordinates will be
+            ignored.
+
+        Returns
+        -------
+        data : array
+            The data values interpolated on the given points.
+
+        """
+        check_is_fitted(self, ["interpolator_"])
+        easting, northing = coordinates[:2]
+        return self.interpolator_((easting, northing))
+
+
+class Linear(_BaseScipyGridder):
+    """
+    A piecewise linear interpolation.
+
+    Provides a Verde interface to
+    :class:`scipy.interpolate.LinearNDInterpolator`.
+
+    Parameters
+    ----------
+    rescale : bool
+        If ``True``, rescale the data coordinates to [0, 1] range before
+        interpolation. Useful when coordinates vary greatly in scale. Default
+        is ``True``.
+
+    Attributes
+    ----------
+    interpolator_ : scipy interpolator class
+        An instance of the corresponding scipy interpolator class.
+    region_ : tuple
+        The boundaries (``[W, E, S, N]``) of the data used to fit the
+        interpolator. Used as the default region for the
+        :meth:`~verde.Linear.grid` and
+        :meth:`~verde.Linear.scatter` methods.
+
+    """
+
+    def __init__(self, rescale=True):
+        super().__init__()
+        self.rescale = rescale
+
+    def _get_interpolator(self):
+        """
+        Return the SciPy interpolator class and any extra keyword arguments as
+        a dictionary.
+        """
+        return LinearNDInterpolator, {"rescale": self.rescale}
+
+
+class ScipyGridder(_BaseScipyGridder):
     """
     A scipy.interpolate based gridder for scalar Cartesian data.
 
@@ -57,37 +186,10 @@ class ScipyGridder(BaseGridder):
         self.method = method
         self.extra_args = extra_args
 
-    def fit(self, coordinates, data, weights=None):
+    def _get_interpolator(self):
         """
-        Fit the interpolator to the given data.
-
-        Any keyword arguments passed as the ``extra_args`` attribute will be
-        used when instantiating the scipy interpolator.
-
-        The data region is captured and used as default for the
-        :meth:`~verde.ScipyGridder.grid` and
-        :meth:`~verde.ScipyGridder.scatter` methods.
-
-        Parameters
-        ----------
-        coordinates : tuple of arrays
-            Arrays with the coordinates of each data point. Should be in the
-            following order: (easting, northing, vertical, ...). Only easting
-            and northing will be used, all subsequent coordinates will be
-            ignored.
-        data : array
-            The data values that will be interpolated.
-        weights : None or array
-            If not None, then the weights assigned to each data point.
-            Typically, this should be 1 over the data uncertainty squared.
-            Ignored for this interpolator. Only present for compatibility with
-            other gridder.
-
-        Returns
-        -------
-        self : verde.ScipyGridder
-            Returns this gridder instance for chaining operations.
-
+        Return the SciPy interpolator class and any extra keyword arguments as
+        a dictionary.
         """
         classes = dict(
             linear=LinearNDInterpolator,
@@ -104,39 +206,4 @@ class ScipyGridder(BaseGridder):
             kwargs = {}
         else:
             kwargs = self.extra_args
-        if weights is not None:
-            warn(
-                "{} does not support weights and they will be ignored.".format(
-                    self.__class__.__name__
-                )
-            )
-        coordinates, data, weights = check_fit_input(coordinates, data, weights)
-        easting, northing = coordinates[:2]
-        self.region_ = get_region((easting, northing))
-        points = np.column_stack((np.ravel(easting), np.ravel(northing)))
-        self.interpolator_ = classes[self.method](points, np.ravel(data), **kwargs)
-        return self
-
-    def predict(self, coordinates):
-        """
-        Interpolate data on the given set of points.
-
-        Requires a fitted gridder (see :meth:`~verde.ScipyGridder.fit`).
-
-        Parameters
-        ----------
-        coordinates : tuple of arrays
-            Arrays with the coordinates of each data point. Should be in the
-            following order: (easting, northing, vertical, ...). Only easting
-            and northing will be used, all subsequent coordinates will be
-            ignored.
-
-        Returns
-        -------
-        data : array
-            The data values interpolated on the given points.
-
-        """
-        check_is_fitted(self, ["interpolator_"])
-        easting, northing = coordinates[:2]
-        return self.interpolator_((easting, northing))
+        return classes[self.method], kwargs

--- a/verde/tests/test_scipy.py
+++ b/verde/tests/test_scipy.py
@@ -15,26 +15,51 @@ import pandas as pd
 import pytest
 
 from ..coordinates import grid_coordinates
-from ..scipygridder import ScipyGridder
+from ..scipygridder import Linear, ScipyGridder
 from ..synthetic import CheckerBoard
 
 
-def test_scipy_gridder_same_points():
+@pytest.mark.parametrize(
+    "gridder",
+    [
+        ScipyGridder(method="nearest"),
+        ScipyGridder(method="linear"),
+        ScipyGridder(method="cubic"),
+        Linear(),
+        Linear(rescale=False),
+    ],
+    ids=[
+        "nearest(scipy)",
+        "linear(scipy)",
+        "cubic(scipy)",
+        "linear",
+        "linear_norescale",
+    ],
+)
+def test_scipy_gridder_same_points(gridder):
     "See if the gridder recovers known points."
     region = (1000, 5000, -8000, -7000)
     synth = CheckerBoard(region=region)
     data = synth.scatter(size=1000, random_state=0)
     coords = (data.easting, data.northing)
     # The interpolation should be perfect on top of the data points
-    for method in ["nearest", "linear", "cubic"]:
-        grd = ScipyGridder(method=method)
-        grd.fit(coords, data.scalars)
-        predicted = grd.predict(coords)
-        npt.assert_allclose(predicted, data.scalars)
-        npt.assert_allclose(grd.score(coords, data.scalars), 1)
+    gridder.fit(coords, data.scalars)
+    predicted = gridder.predict(coords)
+    npt.assert_allclose(predicted, data.scalars)
+    npt.assert_allclose(gridder.score(coords, data.scalars), 1)
 
 
-def test_scipy_gridder():
+@pytest.mark.parametrize(
+    "gridder",
+    [
+        ScipyGridder(method="linear"),
+        ScipyGridder(method="cubic"),
+        Linear(),
+        Linear(rescale=False),
+    ],
+    ids=["linear(scipy)", "cubic(scipy)", "linear", "linear_norescale"],
+)
+def test_scipy_gridder(gridder):
     "See if the gridder recovers known points."
     synth = CheckerBoard(region=(1000, 5000, -8000, -6000))
     data = synth.scatter(size=20000, random_state=0)
@@ -42,22 +67,42 @@ def test_scipy_gridder():
     pt_coords = (3000, -7000)
     true_data = synth.predict(pt_coords)
     # nearest will never be too close to the truth
-    grd = ScipyGridder("cubic").fit(coords, data.scalars)
-    npt.assert_almost_equal(grd.predict(pt_coords), true_data, decimal=2)
-    grd = ScipyGridder("linear").fit(coords, data.scalars)
-    npt.assert_almost_equal(grd.predict(pt_coords), true_data, decimal=1)
+    gridder.fit(coords, data.scalars)
+    npt.assert_almost_equal(gridder.predict(pt_coords), true_data, decimal=1)
 
 
-def test_scipy_gridder_region():
+@pytest.mark.parametrize(
+    "gridder",
+    [
+        ScipyGridder(method="cubic"),
+        Linear(),
+    ],
+    ids=["cubic(scipy)", "linear"],
+)
+def test_scipy_gridder_region_xarray(gridder):
     "See if the region is gotten from the data is correct."
     region = (1000, 5000, -8000, -6000)
     synth = CheckerBoard(region=region)
-    # Test using xarray objects
     grid = synth.grid(shape=(101, 101))
     coords = grid_coordinates(region, grid.scalars.shape)
-    grd = ScipyGridder().fit(coords, grid.scalars)
-    npt.assert_allclose(grd.region_, region)
-    # Test using pandas objects
+    gridder.fit(coords, grid.scalars)
+    npt.assert_allclose(gridder.region_, region)
+
+
+@pytest.mark.parametrize(
+    "gridder",
+    [
+        ScipyGridder(method="cubic"),
+        Linear(),
+    ],
+    ids=["cubic(scipy)", "linear"],
+)
+def test_scipy_gridder_region_pandas(gridder):
+    "See if the region is gotten from the data is correct."
+    region = (1000, 5000, -8000, -6000)
+    synth = CheckerBoard(region=region)
+    grid = synth.grid(shape=(101, 101))
+    coords = grid_coordinates(region, grid.scalars.shape)
     data = pd.DataFrame(
         {
             "easting": coords[0].ravel(),
@@ -65,8 +110,8 @@ def test_scipy_gridder_region():
             "scalars": grid.scalars.values.ravel(),
         }
     )
-    grd = ScipyGridder().fit((data.easting, data.northing), data.scalars)
-    npt.assert_allclose(grd.region_, region)
+    gridder.fit((data.easting, data.northing), data.scalars)
+    npt.assert_allclose(gridder.region_, region)
 
 
 def test_scipy_gridder_extra_args():


### PR DESCRIPTION
This class replaces `ScipyGridder(method="linear")` to provide a nicer
looking interface. It'll also allow us to deprecate `ScipyGridder`
and add an `extrapolate` keyword argument in the future to replace the
NaNs outside of the convex hull with nearest neighbor values.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
