### PR TITLE
Add a Cubic gridder class based on SciPy

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -16,6 +16,7 @@ Interpolators
     Spline
     SplineCV
     Linear
+    Cubic
     VectorSpline2D
     ScipyGridder
 

--- a/doc/gallery_src/cubic_gridder.py
+++ b/doc/gallery_src/cubic_gridder.py
@@ -5,12 +5,12 @@
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
 """
-Gridding with a linear interpolator
+Gridding with a cubic interpolator
 ===================================
 
-Verde offers the :class:`verde.Linear` class for piecewise linear gridding.
-It uses :class:`scipy.interpolate.LinearNDInterpolator` under the hood while
-offering the convenience of Verde's gridder API.
+Verde offers the :class:`verde.Cubic` class for piecewise cubic gridding.
+It uses :class:`scipy.interpolate.CloughTocher2DInterpolator` under the hood
+while offering the convenience of Verde's gridder API.
 
 The interpolation works on Cartesian data, so if we want to grid geographic
 data (like our Baja California bathymetry) we need to project them into a
@@ -18,7 +18,7 @@ Cartesian system. We'll use `pyproj <https://github.com/jswhit/pyproj>`__ to
 calculate a Mercator projection for the data.
 
 For convenience, Verde still allows us to make geographic grids by passing the
-``projection`` argument to :meth:`verde.Linear.grid` and the like. When
+``projection`` argument to :meth:`verde.Cubic.grid` and the like. When
 doing so, the grid will be generated using geographic coordinates which will be
 projected prior to interpolation.
 """
@@ -47,7 +47,7 @@ projection = pyproj.Proj(proj="merc", lat_ts=data.latitude.mean())
 proj_coordinates = projection(*coordinates)
 
 # Now we can set up a gridder for the decimated data
-grd = vd.Linear().fit(proj_coordinates, bathymetry)
+grd = vd.Cubic().fit(proj_coordinates, bathymetry)
 
 # Get the grid region in geographic coordinates
 region = vd.get_region((data.longitude, data.latitude))

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -31,7 +31,7 @@ from .model_selection import (
     train_test_split,
 )
 from .projections import project_grid, project_region
-from .scipygridder import Linear, ScipyGridder
+from .scipygridder import Cubic, Linear, ScipyGridder
 from .spline import Spline, SplineCV
 from .trend import Trend
 from .utils import grid_to_table, make_xarray_grid, maxabs, variance_to_weights

--- a/verde/scipygridder.py
+++ b/verde/scipygridder.py
@@ -114,7 +114,7 @@ class _BaseScipyGridder(BaseGridder):
 
 class Linear(_BaseScipyGridder):
     """
-    A piecewise linear interpolation.
+    Piecewise linear interpolation.
 
     Provides a Verde interface to
     :class:`scipy.interpolate.LinearNDInterpolator`.
@@ -133,8 +133,7 @@ class Linear(_BaseScipyGridder):
     region_ : tuple
         The boundaries (``[W, E, S, N]``) of the data used to fit the
         interpolator. Used as the default region for the
-        :meth:`~verde.Linear.grid` and
-        :meth:`~verde.Linear.scatter` methods.
+        :meth:`~verde.Linear.grid` method.
 
     """
 
@@ -148,6 +147,43 @@ class Linear(_BaseScipyGridder):
         a dictionary.
         """
         return LinearNDInterpolator, {"rescale": self.rescale}
+
+
+class Cubic(_BaseScipyGridder):
+    """
+    Piecewise cubic interpolation.
+
+    Provides a Verde interface to
+    :class:`scipy.interpolate.CloughTocher2DInterpolator`.
+
+    Parameters
+    ----------
+    rescale : bool
+        If ``True``, rescale the data coordinates to [0, 1] range before
+        interpolation. Useful when coordinates vary greatly in scale. Default
+        is ``True``.
+
+    Attributes
+    ----------
+    interpolator_ : scipy interpolator class
+        An instance of the corresponding scipy interpolator class.
+    region_ : tuple
+        The boundaries (``[W, E, S, N]``) of the data used to fit the
+        interpolator. Used as the default region for the
+        :meth:`~verde.Cubic.grid` method.
+
+    """
+
+    def __init__(self, rescale=True):
+        super().__init__()
+        self.rescale = rescale
+
+    def _get_interpolator(self):
+        """
+        Return the SciPy interpolator class and any extra keyword arguments as
+        a dictionary.
+        """
+        return CloughTocher2DInterpolator, {"rescale": self.rescale}
 
 
 class ScipyGridder(_BaseScipyGridder):

--- a/verde/tests/test_scipy.py
+++ b/verde/tests/test_scipy.py
@@ -15,7 +15,7 @@ import pandas as pd
 import pytest
 
 from ..coordinates import grid_coordinates
-from ..scipygridder import Linear, ScipyGridder
+from ..scipygridder import Linear, Cubic, ScipyGridder
 from ..synthetic import CheckerBoard
 
 
@@ -27,6 +27,8 @@ from ..synthetic import CheckerBoard
         ScipyGridder(method="cubic"),
         Linear(),
         Linear(rescale=False),
+        Cubic(),
+        Cubic(rescale=False),
     ],
     ids=[
         "nearest(scipy)",
@@ -34,6 +36,8 @@ from ..synthetic import CheckerBoard
         "cubic(scipy)",
         "linear",
         "linear_norescale",
+        "cubic",
+        "cubic_norescale",
     ],
 )
 def test_scipy_gridder_same_points(gridder):
@@ -56,8 +60,17 @@ def test_scipy_gridder_same_points(gridder):
         ScipyGridder(method="cubic"),
         Linear(),
         Linear(rescale=False),
+        Cubic(),
+        Cubic(rescale=False),
     ],
-    ids=["linear(scipy)", "cubic(scipy)", "linear", "linear_norescale"],
+    ids=[
+        "cubic(scipy)",
+        "cubic(scipy)",
+        "linear",
+        "linear_norescale",
+        "cubic",
+        "cubic_norescale",
+    ],
 )
 def test_scipy_gridder(gridder):
     "See if the gridder recovers known points."

--- a/verde/tests/test_scipy.py
+++ b/verde/tests/test_scipy.py
@@ -15,7 +15,7 @@ import pandas as pd
 import pytest
 
 from ..coordinates import grid_coordinates
-from ..scipygridder import Linear, Cubic, ScipyGridder
+from ..scipygridder import Cubic, Linear, ScipyGridder
 from ..synthetic import CheckerBoard
 
 


### PR DESCRIPTION
This class replaces `ScipyGridder(method="cubic")` to provide a nicer
looking interface. It'll also allow us to deprecate `ScipyGridder`
and add an `extrapolate` keyword argument in the future to replace the
NaNs outside of the convex hull with nearest neighbor values.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
