### PR TITLE
Add `scoring` parameter for SplineCV

### DIFF
--- a/verde/spline.py
+++ b/verde/spline.py
@@ -93,10 +93,10 @@ class SplineCV(BaseGridder):
         allow mod:`dask` to execute the grid search in parallel (see note
         above).
     scoring : None, str, or callable
-        A scoring function (or name of a function) known to scikit-learn. See
-        the description of *scoring* in
+        The scoring function (or name of a function) used for cross-validation.
+        Must be known to scikit-learn. See the description of *scoring* in
         :func:`sklearn.model_selection.cross_val_score` for details. If None,
-        will fall back to the estimator's ``.score`` method.
+        will fall back to the :meth:`verde.Spline.score` method.
 
     Attributes
     ----------

--- a/verde/spline.py
+++ b/verde/spline.py
@@ -92,6 +92,11 @@ class SplineCV(BaseGridder):
         If True, will use :func:`dask.delayed` to dispatch computations and
         allow mod:`dask` to execute the grid search in parallel (see note
         above).
+    scoring : None, str, or callable
+        A scoring function (or name of a function) known to scikit-learn. See
+        the description of *scoring* in
+        :func:`sklearn.model_selection.cross_val_score` for details. If None,
+        will fall back to the estimator's ``.score`` method.
 
     Attributes
     ----------
@@ -134,6 +139,7 @@ class SplineCV(BaseGridder):
         cv=None,
         client=None,
         delayed=False,
+        scoring=None,
     ):
         super().__init__()
         self.dampings = dampings
@@ -143,6 +149,7 @@ class SplineCV(BaseGridder):
         self.cv = cv
         self.client = client
         self.delayed = delayed
+        self.scoring = scoring
         if engine != "auto":
             warnings.warn(
                 "The 'engine' parameter of 'verde.SplineCV' is "
@@ -229,6 +236,7 @@ class SplineCV(BaseGridder):
                     weights=weights,
                     cv=self.cv,
                     delayed=self.delayed,
+                    scoring=self.scoring,
                 )
                 scores.append(dispatch(np.mean, delayed=self.delayed)(score))
         best = dispatch(np.argmax, delayed=self.delayed)(scores)

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -108,7 +108,7 @@ def test_spline_cv_scoring():
     coords = (data.easting, data.northing)
     # Compare SplineCV to results from Spline with cross_val_score
     for score in ["r2", "neg_root_mean_squared_error"]:
-        spline = Spline()
+        spline = Spline(damping=None, mindist=1e-5)
         score_spline = np.mean(
             cross_val_score(spline, coords, data.scalars, scoring=score)
         )

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -115,7 +115,7 @@ def test_spline_cv_scoring():
         # Limit SplineCV to a single parameter set equal to Spline's defaults
         spline_cv = SplineCV(mindists=[1e-5], dampings=[None], scoring=score)
         spline_cv.fit(coords, data.scalars)
-        score_spline_cv = spline_cv.scores_.max()
+        score_spline_cv = spline_cv.scores_[0]
         npt.assert_allclose(score_spline, score_spline_cv, rtol=1e-5)
 
 

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -15,6 +15,7 @@ import pytest
 from dask.distributed import Client
 from sklearn.model_selection import ShuffleSplit
 
+from ..model_selection import cross_val_score
 from ..spline import Spline, SplineCV
 from ..synthetic import CheckerBoard
 from .utils import requires_numba
@@ -97,6 +98,25 @@ def test_spline():
         synth.grid(region=region, shape=shape).scalars,
         rtol=5e-2,
     )
+
+
+def test_spline_cv_scoring():
+    "Check scoring parameter works with SplineCV"
+    region = (100, 500, -800, -700)
+    synth = CheckerBoard(region=region)
+    data = synth.scatter(size=1500, random_state=1)
+    coords = (data.easting, data.northing)
+    # Compare SplineCV to results from Spline with cross_val_score
+    for score in ["r2", "neg_root_mean_squared_error"]:
+        spline = Spline()
+        score_spline = np.mean(
+            cross_val_score(spline, coords, data.scalars, scoring=score)
+        )
+        # Limit SplineCV to a single parameter set equal to Spline's defaults
+        spline_cv = SplineCV(mindists=[1e-5], dampings=[None], scoring=score)
+        spline_cv.fit(coords, data.scalars)
+        score_spline_cv = spline_cv.scores_.max()
+        npt.assert_allclose(score_spline, score_spline_cv, rtol=1e-5)
 
 
 def test_spline_weights():


### PR DESCRIPTION
I've added `scoring` as an additional parameter in `SplineCV` to control the scoring metric used during cross-validation. I've also added a simple test to `test_spline.py`, which checks that results from `SplineCV` using the new scoring parameter match those from standard `Spline` combined with `cross_val_score`. I'm not sure I've put this test in the right place - please let me know if it should be elsewhere.

**Relevant issues/PRs:**

(Hopefully) fixes #379 (see also the discussion [here](https://github.com/orgs/fatiando/discussions/61)).
