### PR TITLE
Simplify the GitHub Actions test workflow matrix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -89,7 +89,7 @@ jobs:
           cat requirements-full.txt
 
       - name: Setup caching for conda packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ env.PYTHON }}-${{ hashFiles('requirements-full.txt') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,11 @@ jobs:
         python:
           - "3.7"
           - "3.10"
-        dependencies:
-          - latest
-          - optional
+        include:
+          - python: "3.7"
+            dependencies: oldest
+          - python: "3.10"
+            dependencies: latest
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions
@@ -112,7 +114,7 @@ jobs:
           cat requirements-full.txt
 
       - name: Setup caching for conda packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ env.PYTHON }}-${{ hashFiles('requirements-full.txt') }}


### PR DESCRIPTION
Run on oldest Python and dependencies and newest Python and dependencies instead of every combination of both. This covers the functionality that we expect to support and produces many fewer workflow runs. Update the cache action to v3 as well.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
