### PR TITLE
Undo deprecation of VectorSpline2D

### DIFF
--- a/doc/tutorials_src/vectors.py
+++ b/doc/tutorials_src/vectors.py
@@ -291,13 +291,5 @@ plt.show()
 #
 # For some types of vector data, like GPS/GNSS displacements, the vector
 # components are coupled through elasticity. In these cases, elastic Green's
-# functions can be used to achieve better interpolation results. The `Erizo
-# package <https://github.com/fatiando/erizo>`__ implements some of these
-# Green's functions.
-#
-# .. warning::
-#
-#     The :class:`verde.VectorSpline2D` class implemented an elastically
-#     coupled Green's function but it is deprecated and will be removed in
-#     Verde v2.0.0. Please use the implementation in the `Erizo
-#     <https://github.com/fatiando/erizo>`__ package instead.
+# functions can be used to achieve better interpolation results. The
+# :class:`verde.VectorSpline2D` implements these Green's functions.

--- a/verde/vector.py
+++ b/verde/vector.py
@@ -7,8 +7,6 @@
 """
 Classes for dealing with vector data.
 """
-import warnings
-
 import numpy as np
 from sklearn.utils.validation import check_is_fitted
 
@@ -145,13 +143,6 @@ class VectorSpline2D(BaseGridder):
     r"""
     Elastically coupled interpolation of 2-component vector data.
 
-    .. warning::
-
-        The :class:`~verde.VectorSpline2D` class is deprecated and will be
-        removed in Verde v2.0.0. Its usage is restricted to GPS/GNSS data and
-        not in the general scope of Verde. Please use the implementation in the
-        `Erizo <https://github.com/fatiando/erizo>`__ package instead.
-
     This gridder assumes Cartesian coordinates.
 
     Uses the Green's functions based on elastic deformation from
@@ -232,12 +223,6 @@ class VectorSpline2D(BaseGridder):
         self.damping = damping
         self.force_coords = force_coords
         self.engine = engine
-        warnings.warn(
-            "VectorSpline2D is deprecated and will be removed in Verde v2.0.0."
-            " Please use the implementation in the Erizo package instead "
-            "(https://github.com/fatiando/erizo).",
-            FutureWarning,
-        )
 
     def fit(self, coordinates, data, weights=None):
         """


### PR DESCRIPTION
This was due to be moved to a separate package. Given that it can be used for different data types and that new package would be quite thin, it's not worth the hassle.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
