### PR TITLE
Add missing matplotlib scraper for sphinx-gallery

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,7 +96,7 @@ sphinx_gallery_conf = {
     # Insert links to documentation of objects in the examples
     "reference_url": {"verde": None},
     # Use the PyGMT image scraper
-    "image_scrapers": ('matplotlib', pygmt.sphinx_gallery.PyGMTScraper()),
+    "image_scrapers": ("matplotlib", pygmt.sphinx_gallery.PyGMTScraper()),
 }
 
 # HTML output configuration

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,7 +96,7 @@ sphinx_gallery_conf = {
     # Insert links to documentation of objects in the examples
     "reference_url": {"verde": None},
     # Use the PyGMT image scraper
-    "image_scrapers": (pygmt.sphinx_gallery.PyGMTScraper(),),
+    "image_scrapers": ('matplotlib', pygmt.sphinx_gallery.PyGMTScraper()),
 }
 
 # HTML output configuration


### PR DESCRIPTION
When enabling PyGMT image scraping, I forgot to add in the matplotlib scraper explicitly.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
