### PR TITLE
Default to not rescale coordinates in Linear/Cubic

### DIFF
--- a/doc/gallery_src/cubic_gridder.py
+++ b/doc/gallery_src/cubic_gridder.py
@@ -87,5 +87,5 @@ plt.colorbar(pc).set_label("meters")
 ax.plot(*coordinates, ".k", markersize=0.1, transform=crs)
 # Use an utility function to setup the tick labels and the land feature
 vd.datasets.setup_baja_bathymetry_map(ax)
-ax.set_title("Linear gridding of bathymetry")
+ax.set_title("Cubic gridding of bathymetry")
 plt.show()

--- a/verde/scipygridder.py
+++ b/verde/scipygridder.py
@@ -124,7 +124,7 @@ class Linear(_BaseScipyGridder):
     rescale : bool
         If ``True``, rescale the data coordinates to [0, 1] range before
         interpolation. Useful when coordinates vary greatly in scale. Default
-        is ``True``.
+        is ``False``.
 
     Attributes
     ----------
@@ -137,7 +137,7 @@ class Linear(_BaseScipyGridder):
 
     """
 
-    def __init__(self, rescale=True):
+    def __init__(self, rescale=False):
         super().__init__()
         self.rescale = rescale
 
@@ -161,7 +161,7 @@ class Cubic(_BaseScipyGridder):
     rescale : bool
         If ``True``, rescale the data coordinates to [0, 1] range before
         interpolation. Useful when coordinates vary greatly in scale. Default
-        is ``True``.
+        is ``False``.
 
     Attributes
     ----------
@@ -174,7 +174,7 @@ class Cubic(_BaseScipyGridder):
 
     """
 
-    def __init__(self, rescale=True):
+    def __init__(self, rescale=False):
         super().__init__()
         self.rescale = rescale
 


### PR DESCRIPTION
Rescaling can have problems and generate unintended outputs. Since Scipy defaults to not rescaling, let's do that here as well.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
