### PR TITLE
Undo deprecation of region/spacing/shape in grid

### DIFF
--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -458,15 +458,6 @@ class BaseGridder(BaseEstimator):
                 "Both coordinates and region were provided. "
                 + "Please pass region only if spacing or shape is specified."
             )
-        # Raise deprecation warning for the region, shape and spacing arguments
-        if spacing is not None or shape is not None or region is not None:
-            warnings.warn(
-                "The 'spacing', 'shape' and 'region' arguments will be removed "
-                + "in Verde v2.0.0. "
-                + "Please use the 'verde.grid_coordinates' function to define "
-                + "grid coordinates and pass them as the 'coordinates' argument.",
-                FutureWarning,
-            )
         # Get grid coordinates from coordinates parameter
         if coordinates is not None:
             ndim = get_ndim_horizontal_coords(*coordinates[:2])

--- a/verde/tests/test_base.py
+++ b/verde/tests/test_base.py
@@ -7,8 +7,6 @@
 """
 Test the base classes and their utility functions.
 """
-import warnings
-
 import numpy as np
 import numpy.testing as npt
 import pytest

--- a/verde/tests/test_base.py
+++ b/verde/tests/test_base.py
@@ -389,15 +389,6 @@ def test_basegridder_grid_invalid_arguments():
     # Check error is raised if both coordinates and region are passed
     with pytest.raises(ValueError):
         grd.grid(coordinates=grid_coords, region=region)
-    # Check if FutureWarning is raised after passing region, spacing or shape
-    with warnings.catch_warnings(record=True) as warns:
-        grd.grid(region=region, shape=(4, 4))
-        assert len(warns) == 1
-        assert issubclass(warns[0].category, FutureWarning)
-    with warnings.catch_warnings(record=True) as warns:
-        grd.grid(region=region, spacing=1)
-        assert len(warns) == 1
-        assert issubclass(warns[0].category, FutureWarning)
 
 
 def test_check_fit_input():


### PR DESCRIPTION
These arguments of the `grid` method were to be removed in favour of generating coordinates in `grid_coordinates` but after experiments this new interface was found to be too verbose and a step backwards from the previous one.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #392 