### PR TITLE
Use Linear/Cubic/KNeighbors in project_grid

### DIFF
--- a/verde/tests/test_projections.py
+++ b/verde/tests/test_projections.py
@@ -12,8 +12,8 @@ import numpy.testing as npt
 import pytest
 import xarray as xr
 
+from ..neighbors import KNeighbors
 from ..projections import project_grid
-from ..scipygridder import ScipyGridder
 
 
 def projection(longitude, latitude):
@@ -23,7 +23,7 @@ def projection(longitude, latitude):
 
 @pytest.mark.parametrize(
     "method",
-    ["nearest", "linear", "cubic", ScipyGridder("nearest")],
+    ["nearest", "linear", "cubic", KNeighbors()],
     ids=["nearest", "linear", "cubic", "gridder"],
 )
 def test_project_grid(method):
@@ -119,3 +119,14 @@ def test_project_grid_fails_dimensions(ndims):
     grid = xr.DataArray(data, coords=coords[:ndims], dims=dims[:ndims])
     with pytest.raises(ValueError):
         project_grid(grid, projection)
+
+
+def test_project_grid_fails_method():
+    "Should fail for invalid method name"
+    shape = (50, 40)
+    lats = np.linspace(2, 10, shape[1])
+    lons = np.linspace(-10, 2, shape[0])
+    data = np.ones(shape, dtype="float")
+    grid = xr.DataArray(data, coords=[lons, lats], dims=("latitude", "longitude"))
+    with pytest.raises(ValueError):
+        project_grid(grid, projection, method="some invalid method")


### PR DESCRIPTION
Now that ScipyGridder is deprecated, use the new classes in this function instead. Doesn't affect the overall interface.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #363 