### PR TITLE
Fix typo in the BaseGridder.fit docstring

### DIFF
--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -277,7 +277,7 @@ class BaseGridder(BaseEstimator):
         Calls ``fit`` on the data, evaluates the residuals (data - predicted
         data), and returns the coordinates, residuals, and weights.
 
-        No very useful by itself but this interface makes gridders compatible
+        Not very useful by itself but this interface makes gridders compatible
         with other processing operations and is used by :class:`verde.Chain` to
         join them together (for example, so you can fit a spline on the
         residuals of a trend).


### PR DESCRIPTION
noticed a typo in the docstrings. 'No very useful' -> 'Not very useful'



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
