### PR TITLE
Move deprecated APIs to their own docs section

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -19,7 +19,6 @@ Interpolators
     Linear
     Cubic
     VectorSpline2D
-    ScipyGridder
 
 Data Processing
 ---------------
@@ -118,33 +117,6 @@ Synthetic data
 
     synthetic.CheckerBoard
 
-
-.. automodule:: verde.datasets
-
-.. currentmodule:: verde
-
-Datasets
---------
-
-.. warning::
-
-    All sample datasets in Verde are deprecated and will be **removed in Verde
-    v2.0.0**. The tutorials/examples will transition to using `Ensaio
-    <https://www.fatiando.org/ensaio/>`__ instead.
-
-.. autosummary::
-   :toctree: generated/
-
-    datasets.locate
-    datasets.fetch_baja_bathymetry
-    datasets.setup_baja_bathymetry_map
-    datasets.fetch_california_gps
-    datasets.setup_california_gps_map
-    datasets.fetch_texas_wind
-    datasets.setup_texas_wind_map
-    datasets.fetch_rio_magnetic
-    datasets.setup_rio_magnetic_map
-
 Base Classes and Functions
 --------------------------
 
@@ -156,3 +128,25 @@ Base Classes and Functions
     base.n_1d_arrays
     base.check_fit_input
     base.least_squares
+
+Deprecated classes and functions
+--------------------------------
+
+The following classes and functions are deprecated and **will be removed in
+Verde 2.0.0**. Alternatives are provided in the function/class docstrings.
+
+.. currentmodule:: verde
+
+.. autosummary::
+   :toctree: generated/
+
+    ScipyGridder
+    datasets.locate
+    datasets.fetch_baja_bathymetry
+    datasets.setup_baja_bathymetry_map
+    datasets.fetch_california_gps
+    datasets.setup_california_gps_map
+    datasets.fetch_texas_wind
+    datasets.setup_texas_wind_map
+    datasets.fetch_rio_magnetic
+    datasets.setup_rio_magnetic_map


### PR DESCRIPTION
The functions and classes that will be removed in Verde 2.0.0 are grouped together at the end of the API docs to help discourage people from relying on them.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
