### PR TITLE
Use a better Spline Green's function for small distances

### DIFF
--- a/doc/gallery_src/spline.py
+++ b/doc/gallery_src/spline.py
@@ -10,10 +10,11 @@ Gridding with splines
 
 Biharmonic spline interpolation is based on estimating vertical forces acting
 on an elastic sheet that yield deformations in the sheet equal to the observed
-data. The results are similar to using :class:`verde.ScipyGridder` with
-``method='cubic'`` but the interpolation is usually a bit slower. However, the
-advantage of using :class:`verde.Spline` is that we can assign weights to the
-data and do model evaluation.
+data. The results are similar to using :class:`verde.Cubic` but the
+interpolation is usually a bit slower. However, the advantages of using
+:class:`verde.Spline` are that the method is able to extrapolate outside of the
+convex hull of the data points and we can assign weights to the data and do
+model evaluation.
 
 .. note::
 
@@ -41,13 +42,11 @@ projection = pyproj.Proj(proj="merc", lat_ts=data.latitude.mean())
 spacing = 15 / 60
 
 # Now we can chain a blocked mean and spline together. The Spline can be
-# regularized by setting the damping coefficient (should be positive). It's
-# also a good idea to set the minimum distance to the average data spacing to
-# avoid singularities in the spline.
+# regularized by setting the damping coefficient (should be positive).
 chain = vd.Chain(
     [
         ("mean", vd.BlockReduce(np.mean, spacing=spacing * 111e3)),
-        ("spline", vd.Spline(damping=1e-10, mindist=100e3)),
+        ("spline", vd.Spline(damping=1e-10)),
     ]
 )
 print(chain)

--- a/doc/gallery_src/spline_cv.py
+++ b/doc/gallery_src/spline_cv.py
@@ -8,17 +8,16 @@
 Gridding with splines (cross-validated)
 =======================================
 
-The :class:`verde.Spline` has two main parameters that need to be configured:
+The :class:`verde.Spline` has one main parameter that needs to be configured:
 
-1. ``mindist``: the minimum distance between forces and data points
-2. ``damping``: the regularization parameter controlling smoothness
+* ``damping``: the regularization parameter controlling smoothness
 
-These parameters can be determined through cross-validation (see
+This parameter can be determined through cross-validation (see
 :ref:`model_selection`) automatically using :class:`verde.SplineCV`. It is very
 similar to :class:`verde.Spline` but takes a set of parameter values instead of
 only one value. When calling :meth:`verde.SplineCV.fit`, the class will:
 
-1. Create a spline for each combination of the input parameter sets
+1. Create a spline for each input parameter value
 2. Calculate the cross-validation score for each spline using
    :func:`verde.cross_val_score`
 3. Pick the spline with the highest score
@@ -43,20 +42,18 @@ spacing = 15 / 60
 
 # This spline will automatically perform cross-validation and search for the
 # optimal parameter configuration.
-spline = vd.SplineCV(dampings=(1e-5, 1e-3, 1e-1), mindists=(10e3, 50e3, 100e3))
+spline = vd.SplineCV(dampings=(1e-5, 1e-3, 1e-1))
 
 # Fit the model on the data. Under the hood, the class will perform K-fold
-# cross-validation for each the 3*3=9 parameter combinations and pick the one
-# with the highest R² score.
+# cross-validation for each the 3 parameter values and pick the one with the
+# highest score.
 spline.fit(projection(*coordinates), data.air_temperature_c)
 
 # We can show the best R² score obtained in the cross-validation
 print("\nScore: {:.3f}".format(spline.scores_.max()))
 
-# And then the best spline parameters that produced this high score.
-print("\nBest spline configuration:")
-print("  mindist:", spline.mindist_)
-print("  damping:", spline.damping_)
+# And then the best damping parameter that produced this high score.
+print("\nBest damping:", spline.damping_)
 
 # Now we can create a geographic grid of air temperature by providing a
 # projection function to the grid method and mask points that are too far from

--- a/doc/gallery_src/vector_uncoupled.py
+++ b/doc/gallery_src/vector_uncoupled.py
@@ -55,7 +55,7 @@ chain = vd.Chain(
         ("trend", vd.Vector([vd.Trend(degree=1) for i in range(2)])),
         (
             "spline",
-            vd.Vector([vd.Spline(damping=1e-10, mindist=500e3) for i in range(2)]),
+            vd.Vector([vd.Spline(damping=1e-10) for i in range(2)]),
         ),
     ]
 )

--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -40,7 +40,6 @@ def test_spline_cv(delayed, client, engine):
     # testing
     spline = SplineCV(
         dampings=[None, 1e3],
-        mindists=[1e-7, 1e6],
         cv=ShuffleSplit(n_splits=1, random_state=0),
         delayed=delayed,
         client=client,
@@ -48,7 +47,6 @@ def test_spline_cv(delayed, client, engine):
     ).fit(coords, data.scalars)
     if client is not None:
         client.close()
-    assert spline.mindist_ == 1e-7
     assert spline.damping_ is None
     # The interpolation should be perfect on top of the data points
     npt.assert_allclose(spline.predict(coords), data.scalars, rtol=1e-5)
@@ -108,12 +106,12 @@ def test_spline_cv_scoring():
     coords = (data.easting, data.northing)
     # Compare SplineCV to results from Spline with cross_val_score
     for score in ["r2", "neg_root_mean_squared_error"]:
-        spline = Spline(damping=None, mindist=1e-5)
+        spline = Spline(damping=None)
         score_spline = np.mean(
             cross_val_score(spline, coords, data.scalars, scoring=score)
         )
         # Limit SplineCV to a single parameter set equal to Spline's defaults
-        spline_cv = SplineCV(mindists=[1e-5], dampings=[None], scoring=score)
+        spline_cv = SplineCV(dampings=[None], scoring=score)
         spline_cv.fit(coords, data.scalars)
         score_spline_cv = spline_cv.scores_[0]
         npt.assert_allclose(score_spline, score_spline_cv, rtol=1e-5)
@@ -154,8 +152,8 @@ def test_spline_damping():
     data = synth.scatter(size=3000, random_state=1)
     coords = (data.easting, data.northing)
     # The interpolation should be close on top of the data points
-    spline = Spline(damping=1e-8, mindist=1000).fit(coords, data.scalars)
-    npt.assert_allclose(spline.predict(coords), data.scalars, rtol=1e-2, atol=1)
+    spline = Spline(damping=1e-8).fit(coords, data.scalars)
+    npt.assert_allclose(spline.predict(coords), data.scalars, rtol=1e-2, atol=10)
     shape = (5, 5)
     region = (2000, 4000, -7500, -6500)
     # Tolerance needs to be kind of high to allow for error due to small


### PR DESCRIPTION
If distance is small change the Green's function to `x(log(x**x)-1)` which evaluates to the correct limit of 0. Deprecate the `mindist` parameter in `Spline` and `SplineCV` since it's no longer needed. Remove use of this parameter from the documentation and present `damping` as the only configurable parameter for the splines.


