### PR TITLE
Fix behavior if spacing >= 2 * interval

### DIFF
--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -249,6 +249,10 @@ def line_coordinates(
     The spacing is adjusted to fit the interval by default but this can be
     changed to adjusting the interval/region instead:
 
+    >>> print(line_coordinates(0, 10, spacing=2.4))
+    [ 0.   2.5  5.   7.5 10. ]
+    >>> print(line_coordinates(0, 10, spacing=2.4, adjust="region"))
+    [0.  2.4 4.8 7.2 9.6]
     >>> print(line_coordinates(0, 10, spacing=2.6))
     [ 0.   2.5  5.   7.5 10. ]
     >>> print(line_coordinates(0, 10, spacing=2.6, adjust="region"))
@@ -277,9 +281,9 @@ def line_coordinates(
         size, stop = spacing_to_size(start, stop, spacing, adjust)
     elif pixel_register:
         # Starts by generating grid-line registered coordinates and shifting
-        # them to the center of the pixel. Need 1 more point if given a shape
-        # so that we can do that because we discard the last point when
-        # shifting the coordinates.
+        # them to the center of the pixel. Need 1 more point if given a size
+        # instead of spacing so that we can do that because we discard the last
+        # point when shifting the coordinates.
         size = size + 1
     values = np.linspace(start, stop, size)
     if pixel_register:
@@ -626,6 +630,14 @@ def spacing_to_size(start, stop, spacing, adjust):
         )
     # Add 1 to get the number of nodes, not segments
     size = int(round((stop - start) / spacing)) + 1
+    # If the spacing >= 2 * (stop - start), it rounds to zero so we'd be
+    # generating a single point, which isn't equivalent to adjusting the
+    # spacing or the region. To get the appropriate behaviour of decreasing the
+    # spacing until it fits the region or increasing the region until it fits
+    # at least 1 spacing, we need to always round to at least 1 in the code
+    # above.
+    if size == 1:
+        size += 1
     if adjust == "region":
         # The size is the same but we adjust the interval so that the spacing
         # isn't altered when we do the linspace.

--- a/verde/tests/test_coordinates.py
+++ b/verde/tests/test_coordinates.py
@@ -136,11 +136,26 @@ def test_line_coordinates_fails():
     # Make sure it doesn't fail for these parameters
     line_coordinates(start, stop, size=size)
     line_coordinates(start, stop, spacing=spacing)
-
     with pytest.raises(ValueError):
         line_coordinates(start, stop)
     with pytest.raises(ValueError):
         line_coordinates(start, stop, size=size, spacing=spacing)
+
+
+def test_line_coordinates_spacing_larger_than_twice_interval():
+    "Check if pixel_register works when the spacing is greater than the limits"
+    start, stop = 0, 1
+    spacing = 3
+    coordinates = line_coordinates(start, stop, spacing=spacing)
+    npt.assert_allclose(coordinates, [0, 1])
+    coordinates = line_coordinates(start, stop, spacing=spacing, pixel_register=True)
+    npt.assert_allclose(coordinates, [0.5])
+    coordinates = line_coordinates(start, stop, spacing=spacing, adjust="region")
+    npt.assert_allclose(coordinates, [0, 3])
+    coordinates = line_coordinates(
+        start, stop, spacing=spacing, pixel_register=True, adjust="region"
+    )
+    npt.assert_allclose(coordinates, [1.5])
 
 
 def test_grid_coordinates_fails():


### PR DESCRIPTION
This was a bug caused by the rounding when calculating the number of nodes in `spacing_to_size`. For the case where the spacing is larger than twice the interval, the size calculating rounded to zero which meant that we were getting a single value for the number of nodes. This is clearly wrong since our behavior is to change the spacing or the region to make sure we always produce at least 2 nodes in the interval.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #404 