### PR TITLE
More informative warning by setting stacklevel=2

### DIFF
--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -93,6 +93,7 @@ def test(doctest=True, verbose=True, coverage=False, figures=True):
         "will be removed in v2.0.0. "
         f"Use 'pytest --pyargs {package}' to run the tests.",
         FutureWarning,
+        stacklevel=2,
     )
 
     assert status == 0, "Some tests have failed."

--- a/verde/base/base_classes.py
+++ b/verde/base/base_classes.py
@@ -361,6 +361,7 @@ class BaseGridder(BaseEstimator):
             "squared error (RMSE) in Verde 2.0.0. "
             "This may change model selection results slightly.",
             FutureWarning,
+            stacklevel=2,
         )
         return score_estimator("r2", self, coordinates, data, weights=weights)
 
@@ -572,6 +573,7 @@ class BaseGridder(BaseEstimator):
             "2.0.0. Use 'verde.scatter_points' and the 'predict' method "
             "instead.",
             FutureWarning,
+            stacklevel=2,
         )
         dims = self._get_dims(dims)
         region = get_instance_region(self, region)

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -1211,7 +1211,8 @@ def _check_rolling_window_overlap(region, size, shape, spacing):
         warnings.warn(
             f"Rolling windows do not overlap (size '{size}' and spacing '{spacing}'). "
             "Some data points may not be included in any window. "
-            "Increase size or decrease spacing to avoid this."
+            "Increase size or decrease spacing to avoid this.",
+            stacklevel=2,
         )
 
 

--- a/verde/datasets/sample_data.py
+++ b/verde/datasets/sample_data.py
@@ -39,6 +39,7 @@ def _datasets_deprecation_warning():
         "removed in Verde v2.0.0. The tutorials/examples will transition "
         "to using Ensaio (https://www.fatiando.org/ensaio/) instead.",
         DeprecationWarning,
+        stacklevel=2,
     )
 
 
@@ -158,7 +159,8 @@ def setup_baja_bathymetry_map(
     if kwargs:
         warnings.warn(
             "All kwargs are being ignored. They are accepted to "
-            + "guarantee backward compatibility."
+            + "guarantee backward compatibility.",
+            stacklevel=2,
         )
     _setup_map(
         ax,
@@ -217,6 +219,7 @@ def fetch_rio_magnetic():
         "The Rio magnetic anomaly dataset is deprecated and will be removed "
         "in Verde v2.0.0. Use a different dataset instead.",
         FutureWarning,
+        stacklevel=2,
     )
     data_file = REGISTRY.fetch("rio-magnetic.csv.xz")
     data = pd.read_csv(data_file, compression="xz")
@@ -250,6 +253,7 @@ def setup_rio_magnetic_map(ax, region=(-42.6, -42, -22.5, -22)):
         "The Rio magnetic anomaly dataset is deprecated and will be removed "
         "in Verde v2.0.0. Use a different dataset instead.",
         FutureWarning,
+        stacklevel=2,
     )
     _setup_map(
         ax,
@@ -337,7 +341,8 @@ def setup_california_gps_map(
     if kwargs:
         warnings.warn(
             "All kwargs are being ignored. They are accepted to "
-            + "guarantee backward compatibility."
+            + "guarantee backward compatibility.",
+            stacklevel=2,
         )
     _setup_map(
         ax,
@@ -416,7 +421,8 @@ def setup_texas_wind_map(ax, region=(-107, -93, 25.5, 37), coastlines=True, **kw
     if kwargs:
         warnings.warn(
             "All kwargs are being ignored. They are accepted to "
-            + "guarantee backward compatibility."
+            + "guarantee backward compatibility.",
+            stacklevel=2,
         )
     _setup_map(
         ax,

--- a/verde/datasets/synthetic.py
+++ b/verde/datasets/synthetic.py
@@ -29,4 +29,5 @@ class CheckerBoard(_CheckerBoard):
             "removed in Verde 2.0.0. "
             "Use verde.synthetic.CheckerBoard instead.",
             FutureWarning,
+            stacklevel=2,
         )

--- a/verde/model_selection.py
+++ b/verde/model_selection.py
@@ -413,6 +413,7 @@ class BlockKFold(BaseBlockCrossValidator):
                     "number of blocks instead. Decreasing n_splits or increasing "
                     "the number of blocks may help.",
                     UserWarning,
+                    stacklevel=2,
                 )
                 folds = [i for _, i in KFold(n_splits=self.n_splits).split(block_ids)]
         else:
@@ -749,6 +750,7 @@ def cross_val_score(
             "and will be removed in Verde 2.0.0. "
             "Use the 'delayed' parameter instead.",
             FutureWarning,
+            stacklevel=2,
         )
     coordinates, data, weights = check_fit_input(
         coordinates, data, weights, unpack=False

--- a/verde/neighbors.py
+++ b/verde/neighbors.py
@@ -97,7 +97,8 @@ class KNeighbors(BaseGridder):
             warnings.warn(
                 "{} does not support weights and they will be ignored.".format(
                     self.__class__.__name__
-                )
+                ),
+                stacklevel=2,
             )
         coordinates, data, weights = check_fit_input(coordinates, data, weights)
         self.region_ = get_region(coordinates[:2])

--- a/verde/spline.py
+++ b/verde/spline.py
@@ -157,6 +157,7 @@ class SplineCV(BaseGridder):
                 "The faster and memory efficient numba engine will be "
                 "the only option.",
                 FutureWarning,
+                stacklevel=2,
             )
         if client is not None:
             warnings.warn(
@@ -164,6 +165,7 @@ class SplineCV(BaseGridder):
                 "deprecated and will be removed in Verde 2.0.0. "
                 "Use the 'delayed' parameter instead.",
                 FutureWarning,
+                stacklevel=2,
             )
 
     def fit(self, coordinates, data, weights=None):
@@ -394,6 +396,7 @@ class Spline(BaseGridder):
                 "The faster and memory efficient numba engine will be "
                 "the only option.",
                 FutureWarning,
+                stacklevel=2,
             )
 
     def fit(self, coordinates, data, weights=None):
@@ -529,7 +532,8 @@ def warn_weighted_exact_solution(spline, weights):
     if weights is not None and spline.damping is None:
         warnings.warn(
             "Weights might have no effect if no regularization is used. "
-            "Use damping or specify force positions that are different from the data."
+            "Use damping or specify force positions that are different from the data.",
+            stacklevel=2,
         )
 
 


### PR DESCRIPTION
Flake8 was complaining about not setting the stacklevel in calls to `warnings.warn`. Fix this linting issue since it's a good thing to set.



