### PR TITLE
Remove mention of "setup.py" from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 # Specify that we use setuptools and setuptools_scm (to generate the version
-# string). Actual configuration is in setup.py and setup.cfg.
+# string). Actual configuration is in setup.cfg.
 [build-system]
 requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Since `setup.py` was removed from Verde, the comment in `pyproject.toml` should be updated and remove "setup.py" from it.