### PR TITLE
Bump actions/download-artifact to v4 in docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -124,13 +124,13 @@ jobs:
 
       # Fetch the built docs from the "build" job
       - name: Download HTML documentation artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: docs-${{ github.sha }}
           path: doc/_build/html
 
       - name: Checkout the gh-pages branch in a separate folder
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+        uses: actions/checkout@v2
         with:
           ref: gh-pages
           # Checkout to this folder instead of the current one


### PR DESCRIPTION
This should fix the deployment of the docs.


