### PR TITLE
Bump pypa/gh-action-pypi-publish to v1.8.12

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -80,7 +80,7 @@ jobs:
       # Store the archives as a build artifact so we can deploy them later
       - name: Upload archives as artifacts
         # Only if not a pull request
-        #if: success() && github.event_name != 'pull_request'
+        if: success() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: pypi-${{ github.sha }}
@@ -93,8 +93,7 @@ jobs:
     needs: build
     environment: pypi
     # Only publish from the origin repository, not forks
-    #if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
-    if: github.repository_owner == 'fatiando'
+    if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
     permissions:
       # This permission allows trusted publishing to PyPI (without an API token)
       id-token: write
@@ -116,7 +115,7 @@ jobs:
 
       - name: Publish to Test PyPI
         # Only publish to TestPyPI when a PR is merged (pushed to main)
-        #if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@v1.8.12
         with:
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -80,7 +80,7 @@ jobs:
       # Store the archives as a build artifact so we can deploy them later
       - name: Upload archives as artifacts
         # Only if not a pull request
-        if: success() && github.event_name != 'pull_request'
+        #if: success() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: pypi-${{ github.sha }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -93,7 +93,8 @@ jobs:
     needs: build
     environment: pypi
     # Only publish from the origin repository, not forks
-    if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
+    #if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
+    if: github.repository_owner == 'fatiando'
     permissions:
       # This permission allows trusted publishing to PyPI (without an API token)
       id-token: write
@@ -115,8 +116,8 @@ jobs:
 
       - name: Publish to Test PyPI
         # Only publish to TestPyPI when a PR is merged (pushed to main)
-        if: success() && github.event_name == 'push'
-        uses: pypa/gh-action-pypi-publish@v1.8.11
+        #if: success() && github.event_name == 'push'
+        uses: pypa/gh-action-pypi-publish@v1.8.12
         with:
           repository_url: https://test.pypi.org/legacy/
           # Allow existing releases on test PyPI without errors.
@@ -126,4 +127,4 @@ jobs:
       - name: Publish to PyPI
         # Only publish to PyPI when a release triggers the build
         if: success() && github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@v1.8.11
+        uses: pypa/gh-action-pypi-publish@v1.8.12


### PR DESCRIPTION
This fixes the failed upload to TestPyPI using Trusted Publishers.