### PR TITLE
Extend support for Python 3.12

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-docs.txt
-      PYTHON: "3.11"
+      PYTHON: "3.12"
 
     steps:
       # Cancel any previous run of the test job

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-build.txt

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,9 @@ jobs:
           - dependencies: oldest
             python: "3.9"
           - dependencies: latest
-            python: "3.11"
+            python: "3.12"
           - dependencies: optional
-            python: "3.11"
+            python: "3.12"
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - python==3.11
+    - python==3.12
     - pip
     # Build
     - twine

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 url = https://github.com/fatiando/verde
 project_urls =
     Documentation = https://www.fatiando.org/verde


### PR DESCRIPTION
Use Python 3.12 as latest version in CI and environment.yml. Update categories in `setup.cfg`.
