### PR TITLE
Ignore flake warning on io module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,8 @@ exclude =
 per-file-ignores =
     # disable unused-imports errors on __init__.py
     __init__.py: F401
+    # disable shadowing of builtin io module (this should be solved)
+    verde/io.py: A005
 
 # Configure flake8-rst-docstrings
 # -------------------------------


### PR DESCRIPTION
Ignore the flake8-builtins `A005` error raised because the `verde.io` module is shadowing the builtin `io` module.
