### PR TITLE
Replace `build` for `python-build` in environment.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,6 +84,14 @@ jobs:
           echo "Collected dependencies:"
           cat requirements-full.txt
 
+      - name: Rename conda-forge packages
+        run: |
+          echo "Rename conda-forge packages in requirements-full.txt"
+          # Replace "build" for "python-build"
+          sed -s --in-place 's/^build$/python-build/' requirements-full.txt
+          echo "Renamed dependencies:"
+          cat requirements-full.txt
+
       - name: Install requirements
         run: conda install --file requirements-full.txt python=$PYTHON -c conda-forge
 

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     - pip
     # Build
     - twine
-    - build
+    - python-build
     # Run
     - numpy
     - scipy


### PR DESCRIPTION
The `build` package in `conda-forge` is outdated, `python-build` should be used instead. Add step in `test.yml` GitHub Action to replace `build` for `python-build` in the collected dependencies that will be installed with conda.
