### PR TITLE
Use pip to install dependencies in test.yml Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,14 @@ jobs:
             python: "3.12"
           - dependencies: optional
             python: "3.12"
+          # test on macos-13 (x86) using oldest dependencies and python 3.9
+          - os: macos-13
+            dependencies: oldest
+            python: "3.9"
+        exclude:
+          # don't test on macos-latest (arm64) with oldest dependencies
+          - os: macos-latest
+            dependencies: oldest
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,11 @@ jobs:
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
+      - name: Echo architechture
+        run: |
+          uname -a
+          uname -p
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,11 +52,12 @@ jobs:
             python: "3.12"
           - dependencies: optional
             python: "3.12"
-          # test on macos-latest with python 3.10
-          - os: macos-latest
+          # test on macos-13 (x86) using oldest dependencies and python 3.9
+          - os: macos-13
             dependencies: oldest
-            python: "3.10"
+            python: "3.9"
         exclude:
+          # don't test on macos-latest (arm64) with oldest dependencies
           - os: macos-latest
             dependencies: oldest
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,14 +52,13 @@ jobs:
             python: "3.12"
           - dependencies: optional
             python: "3.12"
-          # test on macos-13 (x86) using oldest dependencies and python 3.9
-          - os: macos-13
-            dependencies: oldest
-            python: "3.9"
-        exclude:
-          # don't test on macos-latest (arm64) with oldest dependencies
+          # test on macos-latest with python 3.10
           - os: macos-latest
             dependencies: oldest
+            python: "3.10"
+        exclude:
+          - os: macos-latest
+            python: "3.9"
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,16 +31,16 @@ jobs:
   # Run tests and upload to codecov
   test:
     name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       # Otherwise, the workflow would stop if a single job fails. We want to
       # run all of them to catch failures in different combinations.
       fail-fast: false
       matrix:
         os:
-          - ubuntu
-          - macos
-          - windows
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         dependencies:
           - oldest
           - latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,8 @@ jobs:
 
       - name: Install requirements
         run: |
+          which python
+          python --version
           python -m pip install --requirement requirements-full.txt
 
       - name: Build source and wheel distributions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,11 +85,6 @@ jobs:
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
-      - name: Echo architechture
-        run: |
-          uname -a
-          uname -p
-
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
             python: "3.10"
         exclude:
           - os: macos-latest
-            python: "3.9"
+            dependencies: oldest
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,14 +52,6 @@ jobs:
             python: "3.12"
           - dependencies: optional
             python: "3.12"
-          # test on macos-13 (x86) using oldest dependencies and python 3.9
-          - os: macos-13
-            dependencies: oldest
-            python: "3.9"
-        exclude:
-          # don't test on macos-latest (arm64) with oldest dependencies
-          - os: macos-latest
-            dependencies: oldest
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           - optional
         include:
           - dependencies: oldest
-            python: "3.9"
+            python: "3.10"
           - dependencies: latest
             python: "3.12"
           - dependencies: optional

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,14 +60,6 @@ jobs:
       DEPENDENCIES: ${{ matrix.dependencies }}
 
     steps:
-      # Cancel any previous run of the test job
-      # We pin the commit hash corresponding to v0.5.0, and not pinning the tag
-      # because we are giving full access through the github.token.
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ github.token }}
-
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Checkout
         uses: actions/checkout@v4
@@ -85,16 +77,15 @@ jobs:
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON }}
-          channels: conda-forge,defaults
+          python-version: ${{ matrix.python }}
 
       - name: Collect requirements
         run: |
           echo "Install Dependente to capture dependencies:"
-          conda install dependente==0.1.0 -c conda-forge
+          python -m pip install dependente==0.3.0
           echo ""
           echo "Capturing run-time dependencies:"
           if [[ "${{ matrix.dependencies }}" == "oldest" ]]; then
@@ -114,11 +105,27 @@ jobs:
           echo "Collected dependencies:"
           cat requirements-full.txt
 
-      - name: Install requirements
-        run: conda install --quiet --file requirements-full.txt python=$PYTHON
+      - name: Get the pip cache folder
+        id: pip-cache
+        run: |
+          echo "dir="$(pip cache dir) >> $GITHUB_OUTPUT
 
-      - name: List installed packages
-        run: conda list
+      - name: Setup caching for pip packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-full.txt') }}
+
+      - name: Install requirements
+        run: |
+          python -m pip install --requirement requirements-full.txt
+
+      - name: Build source and wheel distributions
+        run: |
+          make build
+          echo ""
+          echo "Generated files:"
+          ls -lh dist/
 
       - name: Build source and wheel distributions
         run: |
@@ -129,6 +136,9 @@ jobs:
 
       - name: Install the package
         run: python -m pip install --no-deps dist/*.whl
+
+      - name: List installed packages
+        run: python -m pip freeze
 
       - name: Copy test data to the cache
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,8 +126,6 @@ jobs:
 
       - name: Install requirements
         run: |
-          which python
-          python --version
           python -m pip install --requirement requirements-full.txt
 
       - name: Build source and wheel distributions

--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -59,3 +59,5 @@ following releases to ensure compatibility:
       - 1.8.0
     * - 3.8
       - 1.8.0
+    * - 3.9
+      - 1.8.1

--- a/env/requirements-test.txt
+++ b/env/requirements-test.txt
@@ -4,3 +4,4 @@ pytest-mpl
 coverage
 matplotlib
 cartopy>=0.18
+dask[distributed]

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     scipy>=1.8
     pandas>=1.4
     xarray>=2022.03
-    scikit-learn>=1.0
+    scikit-learn>=1.1
     pooch>=1.2
     dask>=2022.01.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ packages = find:
 python_requires = >=3.10
 install_requires =
     numpy>=1.25
-    scipy>=1.9
+    scipy>=1.8
     pandas>=1.4
     xarray>=2022.03
     scikit-learn>=1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ packages = find:
 python_requires = >=3.10
 install_requires =
     numpy>=1.25
-    scipy>=1.8
+    scipy>=1.9
     pandas>=1.4
     xarray>=2022.03
     scikit-learn>=1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
     Topic :: Scientific/Engineering
     Topic :: Software Development :: Libraries
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -38,10 +37,10 @@ project_urls =
 zip_safe = True
 include_package_data = True
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
-    numpy>=1.23
-    scipy>=1.8
+    numpy>=1.25
+    scipy>=1.9
     pandas>=1.4
     xarray>=2022.03
     scikit-learn>=1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ packages = find:
 python_requires = >=3.10
 install_requires =
     numpy>=1.25
-    scipy>=1.9
+    scipy>=1.10
     pandas>=1.4
     xarray>=2022.03
     scikit-learn>=1.1


### PR DESCRIPTION
Update the `test.yml` GitHub Action so it makes use of `pip` to install the collected dependencies, instead of having to install Miniforge. Bump `dependente` version to `0.3.0`. Add `dask[distributed]` to `env/requirements-test.txt`.
