### PR TITLE
Don't raise Numpy's precision in doctests

### DIFF
--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -481,8 +481,6 @@ def grid_coordinates(
 
     >>> east, north = grid_coordinates(region=(0, 5, 0, 10), spacing=2.5,
     ...                                pixel_register=True)
-    >>> # Raise the printing precision for this example
-    >>> np.set_printoptions(precision=2, suppress=True)
     >>> # Notice that the shape is 1 less than when pixel_register=False
     >>> print(east.shape, north.shape)
     (4, 2) (4, 2)


### PR DESCRIPTION
Remove lines that used to raise the Numpy's precision on docstring examples. Doctests started to fail on Numpy v2.0.0 due to these lines.

**Relevant issues/PRs:**

Account for missed lines in #462
