### PR TITLE
Use `python-build` in `test.yml` workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           # Choose options to sed based on the OS (macos uses POSIX sed)
           if [[ ${{ matrix.os }} == macos ]]; then
-            opts='-i " "'
+            opts="-i''"
           else
             opts='-s --in-place'
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           echo "Rename conda-forge packages in requirements-full.txt"
           # Replace "build" for "python-build"
-          sed -s --in-place 's/^build$/python-build/' requirements-full.txt
+          sed --in-place 's/^build$/python-build/' requirements-full.txt
           echo "Renamed dependencies:"
           cat requirements-full.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,9 +116,16 @@ jobs:
 
       - name: Rename conda-forge packages
         run: |
+          # Choose options to sed based on the OS (macos uses POSIX sed)
+          if [[ ${{ matrix.os }} == macos ]]; then
+            opts='-i " "'
+          else
+            opts='--in-place'
+          fi
+          echo "OPTS:" $opts
           echo "Rename conda-forge packages in requirements-full.txt"
           # Replace "build" for "python-build"
-          sed --in-place 's/^build$/python-build/' requirements-full.txt
+          sed -s $opts 's/^build$/python-build/' requirements-full.txt
           echo "Renamed dependencies:"
           cat requirements-full.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,14 @@ jobs:
           echo "Collected dependencies:"
           cat requirements-full.txt
 
+      - name: Rename conda-forge packages
+        run: |
+          echo "Rename conda-forge packages in requirements-full.txt"
+          # Replace "build" for "python-build"
+          sed -s --in-place 's/^build$/python-build/' requirements-full.txt
+          echo "Renamed dependencies:"
+          cat requirements-full.txt
+
       - name: Install requirements
         run: conda install --quiet --file requirements-full.txt python=$PYTHON
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,12 +120,12 @@ jobs:
           if [[ ${{ matrix.os }} == macos ]]; then
             opts='-i " "'
           else
-            opts='--in-place'
+            opts='-s --in-place'
           fi
           echo "OPTS:" $opts
           echo "Rename conda-forge packages in requirements-full.txt"
           # Replace "build" for "python-build"
-          sed -s $opts 's/^build$/python-build/' requirements-full.txt
+          sed $opts 's/^build$/python-build/' requirements-full.txt
           echo "Renamed dependencies:"
           cat requirements-full.txt
 


### PR DESCRIPTION
Replace `build` for `python-build` in the `test.yml` workflow before installing the required packages.

**Relevant issues/PRs:**

Apply changes missed in #460
