### PR TITLE
Minor fixes to docs

### DIFF
--- a/doc/tutorials_src/model_evaluation.py
+++ b/doc/tutorials_src/model_evaluation.py
@@ -210,7 +210,7 @@ print("Delayed k-fold scores:", scores)
 # In this case, the scores haven't actually been computed yet (hence the
 # "delayed" term). Instead, Verde scheduled the operations with Dask. Since we
 # are interested only in the mean score, we can schedule the mean as well using
-# :func:`dask.delayed`:
+# :func:`dask.delayed.delayed`:
 
 mean_score = dask.delayed(np.mean)(scores)
 print("Delayed mean:", mean_score)

--- a/doc/tutorials_src/model_selection.py
+++ b/doc/tutorials_src/model_selection.py
@@ -140,8 +140,8 @@ spline = vd.SplineCV(dampings=dampings, delayed=True)
 
 ###############################################################################
 # Unlike :func:`verde.cross_val_score`, calling :meth:`~verde.SplineCV.fit`
-# does **not** result in :func:`dask.delayed` objects. The full grid search is
-# executed and the optimal parameters are found immediately.
+# does **not** result in :func:`dask.delayed.delayed` objects. The full grid
+# search is executed and the optimal parameters are found immediately.
 
 spline.fit(proj_coords, data.air_temperature_c)
 
@@ -149,8 +149,8 @@ print("Best damping:", spline.damping_)
 
 ###############################################################################
 # The one caveat is the that the ``scores_`` attribute will be a list of
-# :func:`dask.delayed` objects instead because the scores are only computed as
-# intermediate values in the scheduled computations.
+# :func:`dask.delayed.delayed` objects instead because the scores are only
+# computed as intermediate values in the scheduled computations.
 
 print("Delayed scores:", spline.scores_)
 

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -135,7 +135,7 @@ def scatter_points(region, size, random_state=None, extra_coords=None):
         permutations. Use a fixed seed to make sure computations are
         reproducible. Use ``None`` to choose a seed automatically (resulting in
         different numbers with each run).
-    extra_coords : None, scalar, or list
+    extra_coords : None, scalar or list
         If not None, then value(s) of extra coordinate arrays to be generated.
         These extra arrays will have the same *size* as the others but will
         contain a constant value. Will generate an extra array per value given
@@ -331,7 +331,7 @@ def grid_coordinates(
         instead of the grid lines. In practice, this means that there will be
         one less element per dimension of the grid when compared to grid line
         registered (only if given *spacing* and not *shape*). Default is False.
-    extra_coords : None, scalar, or list
+    extra_coords : None, scalar or list
         If not None, then value(s) of extra coordinate arrays to be generated.
         These extra arrays will have the same *shape* as the others but will
         contain a constant value. Will generate an extra array per value given
@@ -709,7 +709,7 @@ def profile_coordinates(point1, point2, size, extra_coords=None):
         second point, respectively.
     size : int
         Number of points to sample along the line.
-    extra_coords : None, scalar, or list
+    extra_coords : None, scalar or list
         If not None, then value(s) of extra coordinate arrays to be generated.
         These extra arrays will have the same *size* as the others but will
         contain a constant value. Will generate an extra array per value given

--- a/verde/model_selection.py
+++ b/verde/model_selection.py
@@ -605,11 +605,11 @@ def cross_val_score(
     scoring function (e.g., mean square error, mean absolute error, etc).
 
     Can optionally run in parallel using :mod:`dask`. To do this, use
-    ``delayed=True`` to dispatch computations with :func:`dask.delayed` instead
-    of running them. The returned scores will be "lazy" objects instead of the
-    actual scores. To trigger the computation (which Dask will run in parallel)
-    call the `.compute()` method of each score or :func:`dask.compute` with the
-    entire list of scores.
+    ``delayed=True`` to dispatch computations with :func:`dask.delayed.delayed`
+    instead of running them. The returned scores will be "lazy" objects instead
+    of the actual scores. To trigger the computation (which Dask will run in
+    parallel) call the `.compute()` method of each score or
+    :func:`dask.compute` with the entire list of scores.
 
     .. warning::
 
@@ -639,10 +639,11 @@ def cross_val_score(
         be a dask ``Client`` object. It will be used to dispatch computations
         to the dask cluster.
     delayed : bool
-        If True, will use :func:`dask.delayed` to dispatch computations without
-        actually executing them. The returned scores will be a list of delayed
-        objects. Call `.compute()` on each score or :func:`dask.compute` on the
-        entire list to trigger the actual computations.
+        If True, will use :func:`dask.delayed.delayed` to dispatch computations
+        without actually executing them. The returned scores will be a list of
+        delayed objects. Call `.compute()` on each score or
+        :func:`dask.compute` on the entire list to trigger the actual
+        computations.
     scoring : None, str, or callable
         A scoring function (or name of a function) known to scikit-learn. See
         the description of *scoring* in

--- a/verde/model_selection.py
+++ b/verde/model_selection.py
@@ -70,7 +70,7 @@ class BlockShuffleSplit(BaseBlockCrossValidator):
         absolute number of test samples. If None, the value is set to the
         complement of the train size. If ``train_size`` is also None, it will
         be set to 0.1.
-    train_size : float, int, or None, default=None
+    train_size : float, int or None, default=None
         If float, should be between 0.0 and 1.0 and represent the
         proportion of the dataset to include in the train split. If
         int, represents the absolute number of train samples. If None,
@@ -644,7 +644,7 @@ def cross_val_score(
         delayed objects. Call `.compute()` on each score or
         :func:`dask.compute` on the entire list to trigger the actual
         computations.
-    scoring : None, str, or callable
+    scoring : None, str or callable
         A scoring function (or name of a function) known to scikit-learn. See
         the description of *scoring* in
         :func:`sklearn.model_selection.cross_val_score` for details. If None,

--- a/verde/spline.py
+++ b/verde/spline.py
@@ -94,7 +94,7 @@ class SplineCV(BaseGridder):
         If True, will use :func:`dask.delayed.delayed` to dispatch computations
         and allow mod:`dask` to execute the grid search in parallel (see note
         above).
-    scoring : None, str, or callable
+    scoring : None, str or callable
         The scoring function (or name of a function) used for cross-validation.
         Must be known to scikit-learn. See the description of *scoring* in
         :func:`sklearn.model_selection.cross_val_score` for details. If None,

--- a/verde/spline.py
+++ b/verde/spline.py
@@ -36,15 +36,15 @@ class SplineCV(BaseGridder):
     (or minimum) mean cross-validation score (i.e., a grid search).
 
     This can optionally run in parallel using :mod:`dask`. To do this, use
-    ``delayed=True`` to dispatch computations with :func:`dask.delayed`.
-    In this case, each fit and score operation of the grid search will be
-    performed in parallel.
+    ``delayed=True`` to dispatch computations with
+    :func:`dask.delayed.delayed`. In this case, each fit and score
+    operation of the grid search will be performed in parallel.
 
     .. note::
 
         When using *delayed*, the ``scores_`` attribute will be
-        :func:`dask.delayed` objects instead of the actual scores. This is
-        because the scores are an intermediate step in the computations and
+        :func:`dask.delayed.delayed` objects instead of the actual scores. This
+        is because the scores are an intermediate step in the computations and
         their results are not stored. If you need the scores, run
         :func:`dask.compute` on ``scores_`` to calculate them. Be warned that
         **this will run the grid search again**. It might still be faster than
@@ -91,8 +91,8 @@ class SplineCV(BaseGridder):
         be a dask ``Client`` object. It will be used to dispatch computations
         to the dask cluster.
     delayed : bool
-        If True, will use :func:`dask.delayed` to dispatch computations and
-        allow mod:`dask` to execute the grid search in parallel (see note
+        If True, will use :func:`dask.delayed.delayed` to dispatch computations
+        and allow mod:`dask` to execute the grid search in parallel (see note
         above).
     scoring : None, str, or callable
         The scoring function (or name of a function) used for cross-validation.
@@ -115,8 +115,8 @@ class SplineCV(BaseGridder):
         methods.
     scores_ : array
         The mean cross-validation score for each parameter combination. If
-        ``delayed=True``, will be a list of :func:`dask.delayed` objects (see
-        note above).
+        ``delayed=True``, will be a list of :func:`dask.delayed.delayed`
+        objects (see note above).
     mindist_ : float
         The optimal value for the *mindist* parameter.
     damping_ : float

--- a/verde/utils.py
+++ b/verde/utils.py
@@ -43,7 +43,7 @@ def dispatch(function, delayed=False, client=None):
     function : callable
         The function that will be called.
     delayed : bool
-        If True, will wrap the function in :func:`dask.delayed`.
+        If True, will wrap the function in :func:`dask.delayed.delayed`.
     client : None or dask.distributed Client
         If *delayed* is False and *client* is not None, will return a partial
         execution of the ``client.submit`` with the function as first argument.


### PR DESCRIPTION
When reading through the docs I noticed a few small errors which I've  fix here. 
1) The sphinx cross-referencing to the dask delayed function (:func:`dask.delayed`) was not properly working throughout the docs. It looks like the proper reference for it is :func:`dask.delayed.delayed`.  I've updated all these cross-references.

2) In the typehints of the docstrings the use of an oxford comma seems to result in "or" being treated as an object instead of text; see the docstrings for the scoring parameter of [SplineCV](https://www.fatiando.org/verde/dev/api/generated/verde.SplineCV.html#verde.SplineCV) for an example.  I've removed the oxford comma for a few docstrings that had them. 

I built the docs locally and the changes seem to have worked. 