### PR TITLE
Deploy docs for the 2.0-dev branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,8 @@ on:
   push:
     branches:
       - main
+      # Build and deploy the docs for the 2.0-dev branch as well
+      - 2.0-dev
   release:
     types:
       - published
@@ -152,6 +154,9 @@ jobs:
           if [[ "${{ github.event_name }}" == "release" ]]; then
               # Get the tag name without the "refs/tags/" part
               version="${GITHUB_REF#refs/*/}"
+          elif [[ "${{ github.ref_name }}" == "2.0-dev" ]]; then
+              # Get the tag name without the "refs/tags/" part
+              version=dev2
           else
               version=dev
           fi


### PR DESCRIPTION
Create a "dev2" folder in the gh-pages branch for the 2.0-dev branch docs. This is useful since a lot of the work on 2.0 is a complete rewrite of the docs. Need to undo this before the 2.0 release.

