### PR TITLE
Remove the ScipyGridder class

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -128,16 +128,3 @@ Base Classes and Functions
     base.n_1d_arrays
     base.check_fit_input
     base.least_squares
-
-Deprecated classes and functions
---------------------------------
-
-The following classes and functions are deprecated and **will be removed in
-Verde 2.0.0**. Alternatives are provided in the function/class docstrings.
-
-.. currentmodule:: verde
-
-.. autosummary::
-   :toctree: generated/
-
-    ScipyGridder

--- a/verde/__init__.py
+++ b/verde/__init__.py
@@ -33,7 +33,7 @@ from .model_selection import (
 )
 from .neighbors import KNeighbors
 from .projections import project_grid, project_region
-from .scipygridder import Cubic, Linear, ScipyGridder
+from .scipygridder import Cubic, Linear
 from .spline import Spline, SplineCV
 from .trend import Trend
 from .utils import grid_to_table, make_xarray_grid, maxabs, variance_to_weights

--- a/verde/scipygridder.py
+++ b/verde/scipygridder.py
@@ -11,11 +11,7 @@ from abc import abstractmethod
 from warnings import warn
 
 import numpy as np
-from scipy.interpolate import (
-    CloughTocher2DInterpolator,
-    LinearNDInterpolator,
-    NearestNDInterpolator,
-)
+from scipy.interpolate import CloughTocher2DInterpolator, LinearNDInterpolator
 from sklearn.utils.validation import check_is_fitted
 
 from .base import BaseGridder, check_fit_input
@@ -184,73 +180,3 @@ class Cubic(_BaseScipyGridder):
         a dictionary.
         """
         return CloughTocher2DInterpolator, {"rescale": self.rescale}
-
-
-class ScipyGridder(_BaseScipyGridder):
-    """
-    A scipy.interpolate based gridder for scalar Cartesian data.
-
-    .. warning::
-
-        The ``ScipyGridder`` class is **deprecated** and will be **removed in
-        Verde v2.0.0**. Use :class:`~verde.KNeighbors`, :class:`~verde.Linear`,
-        and :class:`~verde.Cubic` instead.
-
-    Provides a verde gridder interface to the scipy interpolators
-    :class:`scipy.interpolate.LinearNDInterpolator`,
-    :class:`scipy.interpolate.NearestNDInterpolator`, and
-    :class:`scipy.interpolate.CloughTocher2DInterpolator` (cubic).
-
-    Parameters
-    ----------
-    method : str
-        The interpolation method. Either ``'linear'``, ``'nearest'``, or
-        ``'cubic'``.
-    extra_args : None or dict
-        Extra keyword arguments to pass to the scipy interpolator class. See
-        the documentation for each interpolator for a list of possible
-        arguments.
-
-    Attributes
-    ----------
-    interpolator_ : scipy interpolator class
-        An instance of the corresponding scipy interpolator class.
-    region_ : tuple
-        The boundaries (``[W, E, S, N]``) of the data used to fit the
-        interpolator. Used as the default region for the
-        :meth:`~verde.ScipyGridder.grid` and
-        :meth:`~verde.ScipyGridder.scatter` methods.
-
-    """
-
-    def __init__(self, method="cubic", extra_args=None):
-        super().__init__()
-        self.method = method
-        self.extra_args = extra_args
-        warn(
-            "verde.ScipyGridder is deprecated and will be removed in Verde "
-            "v2.0.0. Use the KNeighbors, Linear, and Cubic classes instead.",
-            FutureWarning,
-        )
-
-    def _get_interpolator(self):
-        """
-        Return the SciPy interpolator class and any extra keyword arguments as
-        a dictionary.
-        """
-        classes = dict(
-            linear=LinearNDInterpolator,
-            nearest=NearestNDInterpolator,
-            cubic=CloughTocher2DInterpolator,
-        )
-        if self.method not in classes:
-            raise ValueError(
-                "Invalid interpolation method '{}'. Must be one of {}.".format(
-                    self.method, str(classes.keys())
-                )
-            )
-        if self.extra_args is None:
-            kwargs = {}
-        else:
-            kwargs = self.extra_args
-        return classes[self.method], kwargs

--- a/verde/tests/test_chain.py
+++ b/verde/tests/test_chain.py
@@ -13,7 +13,7 @@ import numpy.testing as npt
 from ..blockreduce import BlockReduce
 from ..chain import Chain
 from ..coordinates import grid_coordinates
-from ..scipygridder import ScipyGridder
+from ..scipygridder import Cubic
 from ..spline import Spline
 from ..synthetic import CheckerBoard
 from ..trend import Trend
@@ -30,7 +30,7 @@ def test_chain():
     trend = coefs[0] + coefs[1] * east + coefs[2] * north
     all_data = trend + data.scalars
 
-    grd = Chain([("trend", Trend(degree=1)), ("gridder", ScipyGridder())])
+    grd = Chain([("trend", Trend(degree=1)), ("gridder", Cubic())])
     grd.fit(coords, all_data)
 
     npt.assert_allclose(grd.predict(coords), all_data)

--- a/verde/tests/test_scipy.py
+++ b/verde/tests/test_scipy.py
@@ -8,6 +8,7 @@
 Test the scipy based interpolator.
 """
 import warnings
+
 import numpy as np
 import numpy.testing as npt
 import pandas as pd

--- a/verde/tests/test_scipy.py
+++ b/verde/tests/test_scipy.py
@@ -8,32 +8,25 @@
 Test the scipy based interpolator.
 """
 import warnings
-
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
 
 from ..coordinates import grid_coordinates
-from ..scipygridder import Cubic, Linear, ScipyGridder
+from ..scipygridder import Cubic, Linear
 from ..synthetic import CheckerBoard
 
 
 @pytest.mark.parametrize(
     "gridder",
     [
-        ScipyGridder(method="nearest"),
-        ScipyGridder(method="linear"),
-        ScipyGridder(method="cubic"),
         Linear(),
         Linear(rescale=False),
         Cubic(),
         Cubic(rescale=False),
     ],
     ids=[
-        "nearest(scipy)",
-        "linear(scipy)",
-        "cubic(scipy)",
         "linear",
         "linear_norescale",
         "cubic",
@@ -56,16 +49,12 @@ def test_scipy_gridder_same_points(gridder):
 @pytest.mark.parametrize(
     "gridder",
     [
-        ScipyGridder(method="linear"),
-        ScipyGridder(method="cubic"),
         Linear(),
         Linear(rescale=False),
         Cubic(),
         Cubic(rescale=False),
     ],
     ids=[
-        "cubic(scipy)",
-        "cubic(scipy)",
         "linear",
         "linear_norescale",
         "cubic",
@@ -87,13 +76,13 @@ def test_scipy_gridder(gridder):
 @pytest.mark.parametrize(
     "gridder",
     [
-        ScipyGridder(method="cubic"),
+        Cubic(),
         Linear(),
     ],
-    ids=["cubic(scipy)", "linear"],
+    ids=["cubic", "linear"],
 )
 def test_scipy_gridder_region_xarray(gridder):
-    "See if the region is gotten from the data is correct."
+    "See if the region gotten from the data is correct."
     region = (1000, 5000, -8000, -6000)
     synth = CheckerBoard(region=region)
     grid = synth.grid(shape=(101, 101))
@@ -105,10 +94,10 @@ def test_scipy_gridder_region_xarray(gridder):
 @pytest.mark.parametrize(
     "gridder",
     [
-        ScipyGridder(method="cubic"),
+        Cubic(),
         Linear(),
     ],
-    ids=["cubic(scipy)", "linear"],
+    ids=["cubic", "linear"],
 )
 def test_scipy_gridder_region_pandas(gridder):
     "See if the region is gotten from the data is correct."
@@ -127,32 +116,21 @@ def test_scipy_gridder_region_pandas(gridder):
     npt.assert_allclose(gridder.region_, region)
 
 
-def test_scipy_gridder_extra_args():
-    "Passing in extra arguments to scipy"
-    data = CheckerBoard().scatter(random_state=100)
-    coords = (data.easting, data.northing)
-    grd = ScipyGridder(method="linear", extra_args=dict(rescale=True))
-    grd.fit(coords, data.scalars)
-    predicted = grd.predict(coords)
-    npt.assert_allclose(predicted, data.scalars)
-
-
-def test_scipy_gridder_fails():
-    "fit should fail for invalid method name"
-    data = CheckerBoard().scatter(random_state=0)
-    grd = ScipyGridder(method="some invalid method name")
-    with pytest.raises(ValueError):
-        grd.fit((data.easting, data.northing), data.scalars)
-
-
-def test_scipy_gridder_warns():
+@pytest.mark.parametrize(
+    "gridder",
+    [
+        Cubic(),
+        Linear(),
+    ],
+    ids=["cubic", "linear"],
+)
+def test_scipy_gridder_warns(gridder):
     "Check that a warning is issued when using weights."
     data = CheckerBoard().scatter(random_state=100)
     weights = np.ones_like(data.scalars)
-    grd = ScipyGridder()
-    msg = "ScipyGridder does not support weights and they will be ignored."
+    msg = "does not support weights and they will be ignored."
     with warnings.catch_warnings(record=True) as warn:
-        grd.fit((data.easting, data.northing), data.scalars, weights=weights)
+        gridder.fit((data.easting, data.northing), data.scalars, weights=weights)
         assert len(warn) == 1
         assert issubclass(warn[-1].category, UserWarning)
-        assert str(warn[-1].message) == msg
+        assert str(warn[-1].message).endswith(msg)


### PR DESCRIPTION
This class was deprecated and replaced by Linear, Cubic, and KNearest. Remove it from the codebase along with tests and docs.

**Relevant issues/PRs:** Fixes #377 