### PR TITLE
Remove the client argument from dask-enabled code

### DIFF
--- a/verde/tests/test_model_selection.py
+++ b/verde/tests/test_model_selection.py
@@ -12,9 +12,7 @@ import warnings
 import numpy as np
 import numpy.testing as npt
 import pytest
-from dask.distributed import Client
 from sklearn.metrics import get_scorer
-from sklearn.model_selection import ShuffleSplit
 
 from .. import Trend, Vector, grid_coordinates, scatter_points
 from ..model_selection import BlockKFold, BlockShuffleSplit, cross_val_score
@@ -53,20 +51,6 @@ def test_cross_val_score_vector(trend, metric, expected):
     model = Vector([Trend(degree=1), Trend(degree=1)])
     scores = cross_val_score(model, coords, (data, data), scoring=metric)
     npt.assert_allclose(scores, expected, atol=1e-10)
-
-
-def test_cross_val_score_client(trend):
-    "Test the deprecated dask Client interface"
-    coords, data = trend[:2]
-    model = Trend(degree=1)
-    nsplits = 5
-    cross_validator = ShuffleSplit(n_splits=nsplits, random_state=0)
-    client = Client(processes=False)
-    futures = cross_val_score(model, coords, data, cv=cross_validator, client=client)
-    scores = [future.result() for future in futures]
-    client.close()
-    assert len(scores) == nsplits
-    npt.assert_allclose(scores, 1)
 
 
 def test_blockshufflesplit_fails_balancing():

--- a/verde/utils.py
+++ b/verde/utils.py
@@ -34,7 +34,7 @@ from .base.utils import (
 )
 
 
-def dispatch(function, delayed=False, client=None):
+def dispatch(function, delayed):
     """
     Decide how to wrap a function for Dask depending on the options given.
 
@@ -44,20 +44,15 @@ def dispatch(function, delayed=False, client=None):
         The function that will be called.
     delayed : bool
         If True, will wrap the function in :func:`dask.delayed.delayed`.
-    client : None or dask.distributed Client
-        If *delayed* is False and *client* is not None, will return a partial
-        execution of the ``client.submit`` with the function as first argument.
 
     Returns
     -------
     function : callable
-        The function wrapped in Dask.
+        The function wrapped in Dask or just itself if *delayed* is False.
 
     """
     if delayed:
         return dask.delayed(function)
-    if client is not None:
-        return functools.partial(client.submit, function)
     return function
 
 


### PR DESCRIPTION
The client argument was deprecated in favor of the delayed interface of Dask. Remove it now from the few places that it was present.

**Relevant issues/PRs:** Closes #351 