### PR TITLE
Remove the engine argument and numpy backend

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -61,13 +61,11 @@ Required:
 * `scikit-learn <http://scikit-learn.org/>`__
 * `pooch <http://www.fatiando.org/pooch/>`__
 * `dask <https://dask.org/>`__
+* `numba <https://numba.pydata.org/>`__
 
 The following are optional dependencies that can make some parts of the code
 more efficient if they are installed:
 
-* `numba <https://numba.pydata.org/>`__: replaces numpy calculations of
-  predictions and Jacobian matrices in splines with faster and more memory
-  efficient multi-threaded versions.
 * `pykdtree <https://github.com/storpipfugl/pykdtree>`__: replaces
   :class:`scipy.spatial.cKDTree` for better performance in near neighbor
   calculations used in blocked operations, distance masking, etc.

--- a/environment.yml
+++ b/environment.yml
@@ -16,9 +16,9 @@ dependencies:
     - scikit-learn
     - pooch
     - dask>=2022.01.0
+    - numba
     # Optional
     - pykdtree
-    - numba
     # Test
     - matplotlib==3.8.*
     - cartopy>=0.20

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,10 +47,10 @@ install_requires =
     scikit-learn>=1.0
     pooch>=1.2
     dask>=2022.01.0
+    numba>=0.55
 
 [options.extras_require]
 fast =
-    numba>=0.55
     pykdtree>=1.3
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     scikit-learn>=1.0
     pooch>=1.2
     dask>=2022.01.0
-    numba>=0.55
+    numba>=0.58
 
 [options.extras_require]
 fast =

--- a/verde/spline.py
+++ b/verde/spline.py
@@ -443,9 +443,7 @@ class Spline(BaseGridder):
         force_east, force_north = n_1d_arrays(force_coords, n=2)
         east, north = n_1d_arrays(coordinates, n=2)
         jac = np.empty((east.size, force_east.size), dtype=dtype)
-        jac = jacobian(
-            east, north, force_east, force_north, self.mindist, jac
-        )
+        jac = jacobian(east, north, force_east, force_north, self.mindist, jac)
         return jac
 
 

--- a/verde/tests/test_utils.py
+++ b/verde/tests/test_utils.py
@@ -7,55 +7,22 @@
 """
 Test the utility functions.
 """
-from unittest import mock
-
 import numpy as np
 import numpy.testing as npt
 import pytest
 import xarray as xr
 from scipy.spatial import cKDTree
 
-from .. import utils
 from ..coordinates import grid_coordinates, scatter_points
 from ..utils import (
-    dummy_jit,
     get_ndim_horizontal_coords,
     grid_to_table,
     kdtree,
     make_xarray_grid,
     meshgrid_from_1d,
     meshgrid_to_1d,
-    parse_engine,
     partition_by_sum,
 )
-
-
-def test_parse_engine():
-    "Check that it works for common input"
-    assert parse_engine("numba") == "numba"
-    assert parse_engine("numpy") == "numpy"
-    with mock.patch.object(utils, "numba", None):
-        assert parse_engine("auto") == "numpy"
-    with mock.patch.object(utils, "numba", mock.MagicMock()):
-        assert parse_engine("auto") == "numba"
-
-
-def test_parse_engine_fails():
-    "Check that the exception is raised for invalid engines"
-    with pytest.raises(ValueError):
-        parse_engine("some invalid engine")
-
-
-def test_dummy_jit():
-    "Make sure the dummy function raises an exception"
-
-    @dummy_jit(target="cpt")
-    def function():
-        "Some random function"
-        return 0
-
-    with pytest.raises(RuntimeError):
-        function()
 
 
 def test_kdtree():

--- a/verde/tests/test_vector.py
+++ b/verde/tests/test_vector.py
@@ -16,7 +16,6 @@ from ..coordinates import grid_coordinates
 from ..synthetic import CheckerBoard
 from ..trend import Trend
 from ..vector import Vector, VectorSpline2D
-from .utils import requires_numba
 
 
 @pytest.fixture
@@ -64,24 +63,6 @@ def test_vector2d_fails(data2d):
         spline.fit(coords, data[0])
     with pytest.raises(ValueError):
         spline.fit(coords, data + coords)
-
-
-@requires_numba
-def test_vector2d_jacobian_implementations(data2d):
-    "Compare the numba and numpy implementations."
-    coords = data2d[0]
-    jac_numpy = VectorSpline2D(engine="numpy").jacobian(coords, coords)
-    jac_numba = VectorSpline2D(engine="numba").jacobian(coords, coords)
-    npt.assert_allclose(jac_numpy, jac_numba)
-
-
-@requires_numba
-def test_vector2d_predict_implementations(data2d):
-    "Compare the numba and numpy implementations."
-    coords, data = data2d
-    pred_numpy = VectorSpline2D(engine="numpy").fit(coords, data).predict(coords)
-    pred_numba = VectorSpline2D(engine="numba").fit(coords, data).predict(coords)
-    npt.assert_allclose(pred_numpy, pred_numba, atol=1e-4)
 
 
 ###############################################################################

--- a/verde/utils.py
+++ b/verde/utils.py
@@ -56,64 +56,6 @@ def dispatch(function, delayed):
     return function
 
 
-def parse_engine(engine):
-    """
-    Choose the best engine available and check if it's valid.
-
-    Parameters
-    ----------
-    engine : str
-        The name of the engine. If ``"auto"`` will favor numba if it's
-        available.
-
-    Returns
-    -------
-    engine : str
-        The name of the engine that should be used.
-
-    """
-    engines = {"auto", "numba", "numpy"}
-    if engine not in engines:
-        raise ValueError("Invalid engine '{}'. Must be in {}.".format(engine, engines))
-    if engine == "auto":
-        if numba is None:
-            return "numpy"
-        return "numba"
-    return engine
-
-
-def dummy_jit(**kwargs):  # noqa: U100
-    """
-    Replace numba.jit if not installed with a function that raises RunTimeError
-
-    Use as a decorator.
-
-    Parameters
-    ----------
-    function
-        A function that you would decorate with :func:`numba.jit`.
-
-    Returns
-    -------
-    function
-        A function that raises :class:`RunTimeError` warning that numba isn't
-        installed.
-
-    """
-
-    def dummy_decorator(function):
-        "The actual decorator"
-
-        @functools.wraps(function)
-        def dummy_function(*args, **kwargs):  # noqa: U100
-            "Just raise an exception."
-            raise RuntimeError("Could not find numba.")
-
-        return dummy_function
-
-    return dummy_decorator
-
-
 def variance_to_weights(variance, tol=1e-15, dtype="float64"):
     """
     Converts data variances to weights for gridding.

--- a/verde/utils.py
+++ b/verde/utils.py
@@ -7,8 +7,6 @@
 """
 General utilities.
 """
-import functools
-
 import dask
 import numpy as np
 import pandas as pd
@@ -19,11 +17,6 @@ try:
     from pykdtree.kdtree import KDTree as pyKDTree
 except ImportError:
     pyKDTree = None  # noqa: N816
-
-try:
-    import numba
-except ImportError:
-    numba = None
 
 from .base.utils import (
     check_coordinates,

--- a/verde/vector.py
+++ b/verde/vector.py
@@ -7,8 +7,6 @@
 """
 Classes for dealing with vector data.
 """
-import warnings
-
 import numba
 import numpy as np
 from sklearn.utils.validation import check_is_fitted
@@ -204,7 +202,11 @@ class VectorSpline2D(BaseGridder):
     """
 
     def __init__(
-        self, poisson=0.5, mindist=10e3, damping=None, force_coords=None,
+        self,
+        poisson=0.5,
+        mindist=10e3,
+        damping=None,
+        force_coords=None,
     ):
         super().__init__()
         self.poisson = poisson
@@ -346,6 +348,7 @@ class VectorSpline2D(BaseGridder):
             east, north, force_east, force_north, self.mindist, self.poisson, jac
         )
         return jac
+
 
 @numba.jit(nopython=True, fastmath=True)
 def greens_function(east, north, mindist, poisson):


### PR DESCRIPTION
Numba will be required from 2.0 and so the slower numpy engine isn't needed anymore. Remove the engine argument from Spline and VectorSpline2D. Remove utils functions that are no longer used. Remove the numpy-based code from both classes.

**Relevant issues/PRs:** Closes #369 