### PR TITLE
Add an option to disable parallelism in splines

### DIFF
--- a/verde/tests/test_spline.py
+++ b/verde/tests/test_spline.py
@@ -21,10 +21,7 @@ from ..synthetic import CheckerBoard
 
 @pytest.mark.parametrize(
     "delayed",
-    [
-        (False,),
-        (True,),
-    ],
+    [(False,), (True,)],
     ids=["serial", "delayed"],
 )
 def test_spline_cv(delayed):


### PR DESCRIPTION
We're using numba's parallel execution in Spline and VectorSpline2D and they're great. But turns out using that in a `ThreadPoolExecutor` (which dask uses) when numba was installed with pip causes a crash. This is because the threading backend that numba uses from pip on Mac (called "workqueue") is not thread-safe and aborts the process when it's inside another threading layer. There are workarounds in the numbagg package but they're complicated and involve caching of jit-compiled functions. We'll use a simpler solution and allow users to turn off parallelism and add a note in the docs about avoiding it when it would cause a crash.


**Relevant issues/PRs:** See discussion in https://github.com/numba/numba/issues/9288 and https://github.com/numbagg/numbagg/pull/201
