### PR TITLE
Remove pykdtree as an optional dependency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,7 +67,7 @@ jobs:
           conda install dependente==0.1.0 -c conda-forge
           echo ""
           echo "Capturing run-time dependencies:"
-          dependente --source install,extras > requirements-full.txt
+          dependente --source install > requirements-full.txt
           echo "Capturing dependencies from:"
           for requirement in $REQUIREMENTS
           do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,13 +41,10 @@ jobs:
         dependencies:
           - oldest
           - latest
-          - optional
         include:
           - dependencies: oldest
             python: "3.10"
           - dependencies: latest
-            python: "3.13"
-          - dependencies: optional
             python: "3.13"
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
@@ -88,8 +85,6 @@ jobs:
           echo "Capturing run-time dependencies:"
           if [[ "${{ matrix.dependencies }}" == "oldest" ]]; then
             dependente --source install --oldest > requirements-full.txt
-          elif [[ "${{ matrix.dependencies }}" == "optional" ]]; then
-            dependente --source install,extras > requirements-full.txt
           else
             dependente --source install > requirements-full.txt
           fi

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -59,16 +59,8 @@ Required:
 * `pandas <http://pandas.pydata.org/>`__
 * `xarray <http://xarray.pydata.org/>`__
 * `scikit-learn <http://scikit-learn.org/>`__
-* `pooch <http://www.fatiando.org/pooch/>`__
 * `dask <https://dask.org/>`__
 * `numba <https://numba.pydata.org/>`__
-
-The following are optional dependencies that can make some parts of the code
-more efficient if they are installed:
-
-* `pykdtree <https://github.com/storpipfugl/pykdtree>`__: replaces
-  :class:`scipy.spatial.cKDTree` for better performance in near neighbor
-  calculations used in blocked operations, distance masking, etc.
 
 Our examples use other packages as well which are not used within Verde itself.
 If you wish to **run the examples in the documentation**, you will also have to
@@ -76,5 +68,4 @@ install:
 
 * `matplotlib <https://matplotlib.org/>`__
 * `pygmt <https://www.pygmt.org>`__ for plotting maps
-* `cartopy <https://scitools.org.uk/cartopy/>`__ for plotting maps
 * `pyproj <https://jswhit.github.io/pyproj/>`__ for cartographic projections

--- a/environment.yml
+++ b/environment.yml
@@ -16,8 +16,6 @@ dependencies:
     - scikit-learn
     - dask>=2022.01.0
     - numba
-    # Optional
-    - pykdtree
     # Test
     - pytest
     - pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,10 +48,6 @@ install_requires =
     dask>=2022.01.0
     numba>=0.58
 
-[options.extras_require]
-fast =
-    pykdtree>=1.3
-
 [flake8]
 max-line-length = 88
 max-doc-length = 79

--- a/verde/coordinates.py
+++ b/verde/coordinates.py
@@ -857,11 +857,6 @@ def block_split(coordinates, spacing=None, adjust="spacing", region=None, shape=
     Alternatively, the number of blocks in the South-North and West-East
     directions can be specified using the *shape* parameter.
 
-    .. note::
-
-        If installed, package ``pykdtree`` will be used instead of
-        :class:`scipy.spatial.cKDTree` for better performance.
-
     Parameters
     ----------
     coordinates : tuple of arrays
@@ -1175,8 +1170,7 @@ def rolling_window(
     centers = grid_coordinates(
         window_region, spacing=spacing, shape=shape, adjust=adjust
     )
-    # pykdtree doesn't support query_ball_point yet and we need that
-    tree = kdtree(coordinates, use_pykdtree=False)
+    tree = kdtree(coordinates)
     # Coordinates must be transposed because the kd-tree wants them as columns
     # of a matrix
     # Use p=inf (infinity norm) to get square windows instead of circular ones
@@ -1366,8 +1360,7 @@ def expanding_window(coordinates, center, sizes):
     coordinates = check_coordinates(coordinates)[:2]
     shape = coordinates[0].shape
     center = np.atleast_2d(center)
-    # pykdtree doesn't support query_ball_point yet and we need that
-    tree = kdtree(coordinates, use_pykdtree=False)
+    tree = kdtree(coordinates)
     indices = []
     for size in sizes:
         # Use p=inf (infinity norm) to get square windows instead of circular

--- a/verde/distances.py
+++ b/verde/distances.py
@@ -32,11 +32,6 @@ def median_distance(coordinates, k_nearest=1, projection=None):
     latitude and longitude, provide a *projection* function to convert them to
     Cartesian before doing the computations.
 
-    .. note::
-
-        If installed, package ``pykdtree`` will be used instead of
-        :class:`scipy.spatial.cKDTree` for better performance.
-
     Parameters
     ----------
     coordinates : tuple of arrays

--- a/verde/mask.py
+++ b/verde/mask.py
@@ -32,12 +32,6 @@ def distance_mask(
     * If *grid* is not None, produces a mask and applies it to *grid* (an
       :class:`xarray.Dataset`).
 
-    .. note::
-
-        If installed, package ``pykdtree`` will be used instead of
-        :class:`scipy.spatial.cKDTree` for better performance.
-
-
     Parameters
     ----------
     data_coordinates : tuple of arrays

--- a/verde/neighbors.py
+++ b/verde/neighbors.py
@@ -31,12 +31,6 @@ class KNeighbors(BaseGridder):
     value by a reduction function, which defaults to the mean. This can also be
     configured.
 
-    .. note::
-
-        If installed, package ``pykdtree`` will be used for the nearest
-        neighbors look-up instead of :class:`scipy.spatial.cKDTree` for better
-        performance.
-
     Parameters
     ----------
     k : int

--- a/verde/tests/test_utils.py
+++ b/verde/tests/test_utils.py
@@ -11,7 +11,6 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 import xarray as xr
-from scipy.spatial import cKDTree
 
 from ..coordinates import grid_coordinates, scatter_points
 from ..utils import (
@@ -28,14 +27,11 @@ from ..utils import (
 def test_kdtree():
     "Test that the kdtree returned works for query"
     coords = grid_coordinates((-10, 0, 0, 20), spacing=1)
-    for use_pykdtree in [True, False]:
-        tree = kdtree(coords, use_pykdtree=use_pykdtree)
-        dist, labels = tree.query(np.array([[-10, 0.1]]))
-        assert labels.size == 1
-        assert labels[0] == 0
-        npt.assert_allclose(dist, 0.1)
-        if not use_pykdtree:
-            assert isinstance(tree, cKDTree)
+    tree = kdtree(coords)
+    dist, labels = tree.query(np.array([[-10, 0.1]]))
+    assert labels.size == 1
+    assert labels[0] == 0
+    npt.assert_allclose(dist, 0.1)
 
 
 def test_grid_to_table_order():

--- a/verde/utils.py
+++ b/verde/utils.py
@@ -11,12 +11,7 @@ import dask
 import numpy as np
 import pandas as pd
 import xarray as xr
-from scipy.spatial import cKDTree
-
-try:
-    from pykdtree.kdtree import KDTree as pyKDTree
-except ImportError:
-    pyKDTree = None  # noqa: N816
+from scipy.spatial import KDTree
 
 from .base.utils import (
     check_coordinates,
@@ -599,19 +594,13 @@ def grid_to_table(grid):
     return pd.DataFrame(data_dict)
 
 
-def kdtree(coordinates, use_pykdtree=True, **kwargs):
+def kdtree(coordinates, **kwargs):
     """
     Create a KD-Tree object with the given coordinate arrays.
 
     Automatically transposes and flattens the coordinate arrays into a single
-    matrix for use in the KD-Tree classes.
-
-    All other keyword arguments are passed to the KD-Tree class.
-
-    If installed, package ``pykdtree`` will be used instead of
-    :class:`scipy.spatial.cKDTree` for better performance. Not all features are
-    available in ``pykdtree`` so if you require the scipy version set
-    ``use_pykdtee=False``.
+    matrix for use in :class:`scipy.spatial.KDTree`. All other keyword
+    arguments are passed to the KD-Tree class.
 
     Parameters
     ----------
@@ -619,22 +608,15 @@ def kdtree(coordinates, use_pykdtree=True, **kwargs):
         Arrays with the coordinates of each data point. Should be in the
         following order: (easting, northing, vertical, ...). All coordinate
         arrays are used.
-    use_pykdtree : bool
-        If True, will prefer ``pykdtree`` (if installed) over
-        :class:`scipy.spatial.cKDTree`. Otherwise, always use the scipy
-        version.
 
     Returns
     -------
-    tree : :class:`scipy.spatial.cKDTree` or ``pykdtree.kdtree.KDTree``
+    tree : :class:`scipy.spatial.KDTree`
         The tree instance initialized with the given coordinates and arguments.
 
     """
     points = np.transpose(n_1d_arrays(coordinates, len(coordinates)))
-    if pyKDTree is not None and use_pykdtree:
-        tree = pyKDTree(points, **kwargs)
-    else:
-        tree = cKDTree(points, **kwargs)
+    tree = KDTree(points, **kwargs)
     return tree
 
 


### PR DESCRIPTION
The newer KDTree in Scipy is already very fast and the difference isn't as big. It's not worth the effort of maintaining an optional dependency in terms of CI runs and code complexity. Since Verde doesn't have optional dependencies now, we don't need the extra run of the CI.