### PR TITLE
Remove line_coordinates which has moved to Bordado

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -56,7 +56,6 @@ Coordinate Manipulation
 .. autosummary::
    :toctree: generated/
 
-    line_coordinates
     grid_coordinates
     scatter_points
     profile_coordinates

--- a/src/verde/__init__.py
+++ b/src/verde/__init__.py
@@ -14,7 +14,6 @@ from .coordinates import (
     get_region,
     grid_coordinates,
     inside,
-    line_coordinates,
     longitude_continuity,
     pad_region,
     profile_coordinates,

--- a/src/verde/coordinates.py
+++ b/src/verde/coordinates.py
@@ -9,6 +9,7 @@ Functions for generating and manipulating coordinates.
 """
 import warnings
 
+import bordado as bd
 import numpy as np
 from sklearn.utils import check_random_state
 
@@ -189,106 +190,6 @@ def scatter_points(region, size, random_state=None, extra_coords=None):
     return tuple(coordinates)
 
 
-def line_coordinates(
-    start, stop, size=None, spacing=None, adjust="spacing", pixel_register=False
-):
-    """
-    Generate evenly spaced points between two values.
-
-    Able to handle either specifying the number of points required (*size*) or
-    the size of the interval between points (*spacing*). If using *size*, the
-    output will be similar to using :func:`numpy.linspace`. When using
-    *spacing*, if the interval is not divisible by the desired spacing, either
-    the interval or the spacing will have to be adjusted. By default, the
-    spacing will be rounded to the nearest multiple. Optionally, the *stop*
-    value can be adjusted to fit the exact spacing given.
-
-    Parameters
-    ----------
-    start : float
-        The starting value of the sequence.
-    stop : float
-        The end value of the sequence.
-    num : int or None
-        The number of points in the sequence. If None, *spacing* must be
-        provided.
-    spacing : float or None
-        The step size (interval) between points in the sequence. If None,
-        *size* must be provided.
-    adjust : {'spacing', 'region'}
-        Whether to adjust the spacing or the interval/region if required.
-        Ignored if *size* is given instead of *spacing*. Defaults to adjusting
-        the spacing.
-    pixel_register : bool
-        If True, the points will refer to the center of each interval (pixel)
-        instead of the boundaries. In practice, this means that there will be
-        one less element in the sequence if *spacing* is provided. If *size* is
-        provided, the requested number of elements is respected. Default is
-        False.
-
-    Returns
-    -------
-    sequence : array
-        The generated sequence of values.
-
-    Examples
-    --------
-
-    >>> values = line_coordinates(0, 5, spacing=2.5)
-    >>> print(values.shape)
-    (3,)
-    >>> print(values)
-    [0.  2.5 5. ]
-    >>> print(line_coordinates(0, 10, size=5))
-    [ 0.   2.5  5.   7.5 10. ]
-    >>> print(line_coordinates(0, 10, spacing=2.5))
-    [ 0.   2.5  5.   7.5 10. ]
-
-    The spacing is adjusted to fit the interval by default but this can be
-    changed to adjusting the interval/region instead:
-
-    >>> print(line_coordinates(0, 10, spacing=2.4))
-    [ 0.   2.5  5.   7.5 10. ]
-    >>> print(line_coordinates(0, 10, spacing=2.4, adjust="region"))
-    [0.  2.4 4.8 7.2 9.6]
-    >>> print(line_coordinates(0, 10, spacing=2.6))
-    [ 0.   2.5  5.   7.5 10. ]
-    >>> print(line_coordinates(0, 10, spacing=2.6, adjust="region"))
-    [ 0.   2.6  5.2  7.8 10.4]
-
-    Optionally, return values at the center of the intervals instead of their
-    boundaries:
-
-    >>> print(line_coordinates(0, 10, spacing=2.5, pixel_register=True))
-    [1.25 3.75 6.25 8.75]
-
-    Notice that this produces one value less than the non-pixel registered
-    version. If using *size* instead of *spacing*, the number of values will be
-    *size* regardless and the spacing will therefore be different from the
-    non-pixel registered version:
-
-    >>> print(line_coordinates(0, 10, size=5, pixel_register=True))
-    [1. 3. 5. 7. 9.]
-
-    """
-    if size is not None and spacing is not None:
-        raise ValueError("Both size and spacing provided. Only one is allowed.")
-    if size is None and spacing is None:
-        raise ValueError("Either a size or a spacing must be provided.")
-    if spacing is not None:
-        size, stop = spacing_to_size(start, stop, spacing, adjust)
-    elif pixel_register:
-        # Starts by generating grid-line registered coordinates and shifting
-        # them to the center of the pixel. Need 1 more point if given a size
-        # instead of spacing so that we can do that because we discard the last
-        # point when shifting the coordinates.
-        size = size + 1
-    values = np.linspace(start, stop, size)
-    if pixel_register:
-        values = values[:-1] + (values[1] - values[0]) / 2
-    return values
-
-
 def grid_coordinates(
     region,
     shape=None,
@@ -456,25 +357,25 @@ def grid_coordinates(
     >>> print(east.shape, north.shape)
     (3, 3) (3, 3)
     >>> print(east)
-    [[-5.  -2.4  0.2]
-     [-5.  -2.4  0.2]
-     [-5.  -2.4  0.2]]
+    [[-5.1 -2.5  0.1]
+     [-5.1 -2.5  0.1]
+     [-5.1 -2.5  0.1]]
     >>> print(north)
-    [[0.  0.  0. ]
-     [2.6 2.6 2.6]
-     [5.2 5.2 5.2]]
+    [[-0.1 -0.1 -0.1]
+     [ 2.5  2.5  2.5]
+     [ 5.1  5.1  5.1]]
     >>> east, north = grid_coordinates(region=(-5, 0, 0, 5), spacing=2.4,
     ...                                adjust='region')
     >>> print(east.shape, north.shape)
     (3, 3) (3, 3)
     >>> print(east)
-    [[-5.  -2.6 -0.2]
-     [-5.  -2.6 -0.2]
-     [-5.  -2.6 -0.2]]
+    [[-4.9 -2.5 -0.1]
+     [-4.9 -2.5 -0.1]
+     [-4.9 -2.5 -0.1]]
     >>> print(north)
-    [[0.  0.  0. ]
-     [2.4 2.4 2.4]
-     [4.8 4.8 4.8]]
+    [[0.1 0.1 0.1]
+     [2.5 2.5 2.5]
+     [4.9 4.9 4.9]]
 
     We can optionally generate coordinates for the center of each grid pixel
     instead of the corner (default):
@@ -542,7 +443,6 @@ def grid_coordinates(
     --------
     scatter_points : Generate the coordinates for a random scatter of points
     profile_coordinates : Coordinates for a profile between two points
-    line_coordinates: Generate evenly spaced points between two values
 
     """
     check_region(region)
@@ -561,7 +461,7 @@ def grid_coordinates(
     else:
         spacing = (None, None)
 
-    east = line_coordinates(
+    east = bd.line_coordinates(
         region[0],
         region[1],
         size=shape[1],
@@ -569,7 +469,7 @@ def grid_coordinates(
         adjust=adjust,
         pixel_register=pixel_register,
     )
-    north = line_coordinates(
+    north = bd.line_coordinates(
         region[2],
         region[3],
         size=shape[0],
@@ -588,55 +488,6 @@ def grid_coordinates(
         for value in np.atleast_1d(extra_coords):
             coordinates.append(np.ones_like(coordinates[0]) * value)
     return tuple(coordinates)
-
-
-def spacing_to_size(start, stop, spacing, adjust):
-    """
-    Convert a spacing to the number of points between start and stop.
-
-    Takes into account if the spacing or the interval needs to be adjusted.
-
-    Parameters
-    ----------
-    start : float
-        The starting value of the sequence.
-    stop : float
-        The end value of the sequence.
-    spacing : float
-        The step size (interval) between points in the sequence.
-    adjust : {'spacing', 'region'}
-        Whether to adjust the spacing or the interval/region if required.
-        Defaults to adjusting the spacing.
-
-    Returns
-    -------
-    size : int
-        The number of points between start and stop.
-    stop : float
-        The end of the interval, which may or may not have been adjusted.
-
-    """
-    if adjust not in ["spacing", "region"]:
-        raise ValueError(
-            "Invalid value for *adjust* '{}'. Should be 'spacing' or 'region'".format(
-                adjust
-            )
-        )
-    # Add 1 to get the number of nodes, not segments
-    size = int(round((stop - start) / spacing)) + 1
-    # If the spacing >= 2 * (stop - start), it rounds to zero so we'd be
-    # generating a single point, which isn't equivalent to adjusting the
-    # spacing or the region. To get the appropriate behaviour of decreasing the
-    # spacing until it fits the region or increasing the region until it fits
-    # at least 1 spacing, we need to always round to at least 1 in the code
-    # above.
-    if size == 1:
-        size += 1
-    if adjust == "region":
-        # The size is the same but we adjust the interval so that the spacing
-        # isn't altered when we do the linspace.
-        stop = start + (size - 1) * spacing
-    return size, stop
 
 
 def shape_to_spacing(region, shape, pixel_register=False):

--- a/test/test_coordinates.py
+++ b/test/test_coordinates.py
@@ -16,11 +16,9 @@ import pytest
 from verde.coordinates import (
     check_region,
     grid_coordinates,
-    line_coordinates,
     longitude_continuity,
     profile_coordinates,
     rolling_window,
-    spacing_to_size,
 )
 
 
@@ -92,65 +90,6 @@ def test_rolling_window_oversized_window(region):
     err_msg = f"Window size '{oversize}' is larger than dimensions of the region "
     with pytest.raises(ValueError, match=err_msg):
         rolling_window(coords, size=oversize, spacing=2)
-
-
-def test_spacing_to_size():
-    "Check that correct size and stop are returned"
-    start, stop = -10, 0
-
-    size, new_stop = spacing_to_size(start, stop, spacing=2.5, adjust="spacing")
-    npt.assert_allclose(size, 5)
-    npt.assert_allclose(new_stop, stop)
-
-    size, new_stop = spacing_to_size(start, stop, spacing=2, adjust="spacing")
-    npt.assert_allclose(size, 6)
-    npt.assert_allclose(new_stop, stop)
-
-    size, new_stop = spacing_to_size(start, stop, spacing=2.6, adjust="spacing")
-    npt.assert_allclose(size, 5)
-    npt.assert_allclose(new_stop, stop)
-
-    size, new_stop = spacing_to_size(start, stop, spacing=2.4, adjust="spacing")
-    npt.assert_allclose(size, 5)
-    npt.assert_allclose(new_stop, stop)
-
-    size, new_stop = spacing_to_size(start, stop, spacing=2.6, adjust="region")
-    npt.assert_allclose(size, 5)
-    npt.assert_allclose(new_stop, 0.4)
-
-    size, new_stop = spacing_to_size(start, stop, spacing=2.4, adjust="region")
-    npt.assert_allclose(size, 5)
-    npt.assert_allclose(new_stop, -0.4)
-
-
-def test_line_coordinates_fails():
-    "Check failures for invalid arguments"
-    start, stop = 0, 1
-    size = 10
-    spacing = 0.1
-    # Make sure it doesn't fail for these parameters
-    line_coordinates(start, stop, size=size)
-    line_coordinates(start, stop, spacing=spacing)
-    with pytest.raises(ValueError):
-        line_coordinates(start, stop)
-    with pytest.raises(ValueError):
-        line_coordinates(start, stop, size=size, spacing=spacing)
-
-
-def test_line_coordinates_spacing_larger_than_twice_interval():
-    "Check if pixel_register works when the spacing is greater than the limits"
-    start, stop = 0, 1
-    spacing = 3
-    coordinates = line_coordinates(start, stop, spacing=spacing)
-    npt.assert_allclose(coordinates, [0, 1])
-    coordinates = line_coordinates(start, stop, spacing=spacing, pixel_register=True)
-    npt.assert_allclose(coordinates, [0.5])
-    coordinates = line_coordinates(start, stop, spacing=spacing, adjust="region")
-    npt.assert_allclose(coordinates, [0, 3])
-    coordinates = line_coordinates(
-        start, stop, spacing=spacing, pixel_register=True, adjust="region"
-    )
-    npt.assert_allclose(coordinates, [1.5])
 
 
 def test_grid_coordinates_fails():


### PR DESCRIPTION
This function was moved to Bordado. Remove it from the codebase and use the Bordado version. Also removed the `spacing_to_size` function which was only used by `line_coordinates`. Remove the associated tests and the API entry.

**Relevant issues/PRs:** #497 