### PR TITLE
Fix sphinx warnings about autosummary stub files

### DIFF
--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -4,22 +4,10 @@
 
 .. autoclass:: {{ objname }}
 
-{% if attributes %}
-
-Attributes
-----------
-
-{% for item in attributes %}
-.. autoattribute:: {{ objname }}.{{ item }}
-{% endfor %}
-
-{% endif %}
-
-
 {% if methods %}
 
-Methods
--------
+Method documentation
+--------------------
 
 {% for item in methods %}
 {% if item != '__init__' %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,8 +43,6 @@ intersphinx_mapping = {
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "xarray": ("https://docs.xarray.dev/en/stable/", None),
-    "cartopy": ("https://scitools.org.uk/cartopy/docs/latest/", None),
-    "pooch": ("https://www.fatiando.org/pooch/latest/", None),
     "ensaio": ("https://www.fatiando.org/ensaio/latest/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "dask": ("https://docs.dask.org/en/latest/", None),
@@ -58,9 +56,11 @@ autosummary_generate = []
 # Create cross-references for the parameter types in the Parameters, Other
 # Returns and Yields sections of the docstring
 numpydoc_xref_param_type = True
-
 # Format the Attributes like the Parameters section.
 numpydoc_attributes_as_param_list = True
+# Disable the creation of a toctree for class members to avoid missing stub
+# file warnings. See https://stackoverflow.com/a/73294408
+numpydoc_class_members_toctree = False
 
 # Always show the source code that generates a plot
 plot_include_source = True


### PR DESCRIPTION
The combination of autosummary and numpydoc was causing warnings about missing stub files because numpydoc was building a toctree for methods but the pages didn't exist (they are all in the main page). Disable this option and remove the attribute autogenerated pages since we already describe important attributes in the docstring.
