### PR TITLE
Fix undamped least-squares to keep full precision on scikit-learn >= 1.9 (#558)

### DIFF
--- a/verde/base/least_squares.py
+++ b/verde/base/least_squares.py
@@ -10,7 +10,8 @@ Functions for least-squares fitting with optional regularization.
 from warnings import warn
 
 import numpy as np
-from sklearn.linear_model import LinearRegression, Ridge
+from scipy.linalg import lstsq
+from sklearn.linear_model import Ridge
 from sklearn.preprocessing import StandardScaler
 
 
@@ -62,10 +63,29 @@ def least_squares(jacobian, data, weights, damping=None, copy_jacobian=False):
         )
     scaler = StandardScaler(copy=copy_jacobian, with_mean=False, with_std=True)
     jacobian = scaler.fit_transform(jacobian)
+    data = np.ravel(data)
     if damping is None:
-        regr = LinearRegression(fit_intercept=False)
+        # Solve the undamped problem directly with scipy.linalg.lstsq
+        # instead of sklearn's LinearRegression. Since scikit-learn 1.9,
+        # LinearRegression.fit passes its ``tol`` (default 1e-6) as the
+        # ``cond`` argument of scipy.linalg.lstsq, truncating small
+        # singular values. That silently degrades the fit for the
+        # ill-conditioned Jacobians produced by Spline, so undamped
+        # predictions no longer match the training data. Passing
+        # ``cond=None`` keeps the full-precision solution regardless of
+        # the scikit-learn version. See #558.
+        if weights is None:
+            coef = lstsq(jacobian, data, cond=None)[0]
+        else:
+            sqrt_weights = np.sqrt(np.ravel(weights))
+            coef = lstsq(
+                jacobian * sqrt_weights[:, np.newaxis],
+                data * sqrt_weights,
+                cond=None,
+            )[0]
+        params = coef / scaler.scale_
     else:
         regr = Ridge(alpha=damping, fit_intercept=False)
-    regr.fit(jacobian, np.ravel(data), sample_weight=weights)
-    params = regr.coef_ / scaler.scale_
+        regr.fit(jacobian, data, sample_weight=weights)
+        params = regr.coef_ / scaler.scale_
     return params

--- a/verde/tests/test_base.py
+++ b/verde/tests/test_base.py
@@ -467,3 +467,37 @@ def test_least_squares_copy_jacobian():
     npt.assert_allclose(jacobian, original_jacobian)
     least_squares(jacobian, data, weights=None)
     assert not np.allclose(jacobian, original_jacobian)
+
+
+def test_least_squares_undamped_full_precision():
+    """
+    Undamped least-squares must recover the full-precision solution.
+
+    Regression test for #558: since scikit-learn 1.9, LinearRegression.fit
+    passes its ``tol`` (default 1e-6) as ``cond`` to scipy.linalg.lstsq, which
+    truncates small singular values and silently degrades the fit for the
+    ill-conditioned Jacobians produced by Spline. For a full-rank square
+    system, the undamped fit must reproduce the data to near machine precision.
+    """
+    rng = np.random.default_rng(42)
+    n_params = 25
+    left = np.linalg.qr(rng.standard_normal((n_params, n_params)))[0]
+    right = np.linalg.qr(rng.standard_normal((n_params, n_params)))[0]
+    # Ill-conditioned but full-rank: singular values spanning 1 down to 1e-8.
+    jacobian = (left * np.logspace(0, -8, n_params)) @ right.T
+    true_params = rng.standard_normal(n_params)
+    data = jacobian @ true_params
+    params = least_squares(jacobian.copy(), data, weights=None)
+    npt.assert_allclose(jacobian @ params, data, atol=1e-10)
+
+
+def test_least_squares_undamped_weights():
+    """
+    Undamped least-squares with uniform weights matches the unweighted fit.
+    """
+    rng = np.random.default_rng(0)
+    jacobian = rng.standard_normal((30, 5))
+    data = rng.standard_normal(30)
+    unweighted = least_squares(jacobian.copy(), data, weights=None)
+    weighted = least_squares(jacobian.copy(), data, weights=np.ones(30))
+    npt.assert_allclose(weighted, unweighted)


### PR DESCRIPTION
Fixes #558.

### Problem

Since scikit-learn 1.9, `LinearRegression.fit` passes its `tol` attribute (default `1e-6`) as the `cond` argument of `scipy.linalg.lstsq`, which truncates small singular values. For the ill-conditioned Jacobians produced by `Spline`, the **undamped** fit (`damping=None`) then silently returns predictions that no longer match the training data. No exception is raised.

This also affects:

- `SplineCV` whenever cross-validation selects `damping=None` (the common outcome for near-noise-free data)
- anything chaining an undamped spline, e.g. `Chain([..., ("spline", Spline())])`

On scikit-learn >= 1.9 this makes `test_spline.py::test_spline`, `test_spline_cv[...]`, and `test_chain.py::test_chain_double` fail.

### Fix

Solve the undamped case directly with `scipy.linalg.lstsq(cond=None)` instead of `sklearn.LinearRegression`, so the full-precision solution is used regardless of the scikit-learn version. Weighted fits are handled by row-scaling the Jacobian and data by `sqrt(weights)`, which is equivalent to `LinearRegression`'s `sample_weight`. The damped path (`Ridge`) is unchanged.

This also moves the undamped path off the scikit-learn estimator, in the direction you mentioned in the issue. I kept the change minimal and surgical (undamped path only) rather than reworking the damped path too; happy to widen the scope if you'd prefer.

### Tests

Red-green verified against scikit-learn 1.9.0:

- The existing real-trigger tests (`test_spline`, `test_spline_cv`, `test_chain_double`) fail on `main` with scikit-learn >= 1.9 and pass with this change.
- Added `test_least_squares_undamped_full_precision`: an ill-conditioned full-rank system whose undamped fit must reproduce the data to near machine precision. Fails before this change (max abs error ~1.8e-7) and passes after (~5e-16).
- Added `test_least_squares_undamped_weights`: uniform weights match the unweighted fit, guarding the new weighted path.

`black`, `isort`, and `flake8` (repo-pinned versions) are clean.

---
Disclosure: I used AI assistance (Claude) while preparing this change. I verified the root cause, ran the tests (red-green), and take responsibility for the contribution.
